### PR TITLE
Feature/28 소셜 로그인 redirect uri, 소셜 닉네임 저장 수정

### DIFF
--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
       client:
         registration:
           kakao:
-            redirect-uri: https://tokstudy.com/login/oauth2/code/kakao
+            redirect-uri: https://api.tokstudy.com/login/oauth2/code/kakao
 url:
   prefix: <dev url>
   study-path: /study

--- a/core/src/main/java/com/tdns/toks/core/common/security/oauth/OAuth2Attribute.java
+++ b/core/src/main/java/com/tdns/toks/core/common/security/oauth/OAuth2Attribute.java
@@ -33,13 +33,12 @@ public class OAuth2Attribute {
     private static OAuth2Attribute ofKakao(String attributeKey,
                                            Map<String, Object> attributes) {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
         Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
         return OAuth2Attribute.builder()
                 .provider(UserProvider.KAKAO)
                 .providerId(String.valueOf(attributes.get("id")))
                 .email((String) kakaoAccount.get("email"))
-                .nickname((String) properties.get("nickname"))
+                .nickname("닉네임을 등록해주세요")
                 .thumbnailImageUrl((String) profile.get("thumbnail_image_url"))
                 .profileImageUrl((String) profile.get("profile_image_url"))
                 .attributes(kakaoAccount)

--- a/core/src/main/java/com/tdns/toks/core/domain/study/model/entity/StudyTag.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/model/entity/StudyTag.java
@@ -15,13 +15,13 @@ import java.io.Serializable;
 public class StudyTag extends BaseTimeEntity implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", columnDefinition = "스터디 태그 번호")
+    @Column(name = "id", columnDefinition = "BIGINT COMMENT '스터디 태그 번호'")
     private Long id;
 
-    @Column(name = "study_id", columnDefinition = "스터디 번호")
+    @Column(name = "study_id", columnDefinition = "BIGINT COMMENT '스터디 번호'")
     private Long studyId;
 
-    @Column(name = "tag_id", columnDefinition = "태그 번호")
+    @Column(name = "tag_id", columnDefinition = "BIGINT COMMENT '태그 번호'")
     private Long tagId;
 
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/study/model/entity/Tag.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/model/entity/Tag.java
@@ -15,9 +15,9 @@ import java.io.Serializable;
 public class Tag extends BaseTimeEntity implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "id", columnDefinition = "태그 번호")
+    @Column(name = "id", columnDefinition = "BIGINT COMMENT '태그 번호'")
     private Long id;
 
-    @Column(name = "name", columnDefinition = "태그 이름")
+    @Column(name = "name", columnDefinition = "VARCHAR(20) COMMENT '태그 이름'")
     private String name;
 }


### PR DESCRIPTION
## ✔️ PR 타입

- 수정

## 📃 개요
- redirect uri 변경
- 카카오 첫 로그인 플로우 개선
- 실행 시 columnDefinition 오류 발생

## ✏️ 변경사항
- api.tokstudy.com 으로 redirecturi 변경
- 카카오 첫 로그인 시 반드시 닉네임 설정 페이지로 이동할 수 있도록 카카오에서 넘어오는 nickname 사용하지 않음.
- "닉네임을 등록해주세요"로 일괄 저장
- columnDefinition 일부 수정

## 🫥 TODO
