### PR TITLE
#34 답변 다건 조회

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/UserQuizHistoryController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/UserQuizHistoryController.java
@@ -2,9 +2,12 @@ package com.tdns.toks.api.domain.quiz.controller;
 
 import static com.tdns.toks.api.domain.quiz.model.dto.UserQuizHistoryApiDTO.*;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,6 +43,25 @@ public class UserQuizHistoryController {
 		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
 	public ResponseEntity<UserQuizHistoryResponse> submit(@Validated final UserQuizHistoryRequest request) {
 		var response = userQuizHistoryApiService.submit(request);
+		return ResponseDto.ok(response);
+	}
+
+	@GetMapping("/quizzes/{quizId}")
+	@Operation(
+		method = "Get",
+		summary = "퀴즈 답변 다건 조회"
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = UserQuizHistoryResponse.class))}),
+		@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+		@ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
+		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
+	public ResponseEntity<UserQuizHistoriesResponse> getAllByQuizId(
+		@PathVariable final Long quizId,
+		final Pageable pageable
+	) {
+		var response = userQuizHistoryApiService.getAllByQuizId(quizId, pageable);
 		return ResponseDto.ok(response);
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/UserQuizHistoryController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/UserQuizHistoryController.java
@@ -52,7 +52,7 @@ public class UserQuizHistoryController {
 		summary = "퀴즈 답변 다건 조회"
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = UserQuizHistoryResponse.class))}),
+		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UserQuizHistoriesResponse.class))}),
 		@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
 		@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
 		@ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/UserQuizHistoryApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/UserQuizHistoryApiDTO.java
@@ -1,7 +1,10 @@
 package com.tdns.toks.api.domain.quiz.model.dto;
 
+import java.util.List;
+
 import javax.validation.constraints.NotEmpty;
 
+import com.tdns.toks.core.domain.quiz.model.dto.UserQuizHistoryDto;
 import com.tdns.toks.core.domain.quiz.model.entity.UserQuizHistory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -41,5 +44,14 @@ public class UserQuizHistoryApiDTO {
 				userQuizHistory.getQuizId()
 			);
 		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Schema(name = "UserQuizHistoriesResponse", description = "USER QUIZ HISTORY 생성 응답 모델")
+	public static class UserQuizHistoriesResponse {
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "user quiz history 리스트", description = "user quiz history 리스트")
+		private List<UserQuizHistoryDto> userQuizHistories;
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/UserQuizHistoryApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/UserQuizHistoryApiService.java
@@ -2,6 +2,7 @@ package com.tdns.toks.api.domain.quiz.service;
 
 import static com.tdns.toks.api.domain.quiz.model.dto.UserQuizHistoryApiDTO.*;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,5 +25,10 @@ public class UserQuizHistoryApiService {
 		quizService.getOrThrow(request.getQuizId());
 		userQuizHistoryService.checkAlreadySubmitted(request.getQuizId(), UserDetailDTO.get().getId());
 		return UserQuizHistoryResponse.toResponse(userQuizHistoryService.save(mapper.toEntity(request)));
+	}
+
+	public UserQuizHistoriesResponse getAllByQuizId(final Long quizId, final Pageable pageable) {
+		var quiz = quizService.getOrThrow(quizId);
+		return new UserQuizHistoriesResponse(userQuizHistoryService.getAllByQuizId(quiz.getId(), pageable));
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/UserQuizHistoryDto.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/UserQuizHistoryDto.java
@@ -1,0 +1,22 @@
+package com.tdns.toks.core.domain.quiz.model.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserQuizHistoryDto {
+
+	private Long userQuizHistoryId;
+	private String answer;
+	private Long likeNumber;
+	private UserSimpleDTO creator;
+
+	@Getter
+	@NoArgsConstructor
+	public static class UserSimpleDTO {
+		private Long userId;
+		private String nickname;
+		private String profileImageUrl;
+	}
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/UserQuizHistoryDto.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/UserQuizHistoryDto.java
@@ -1,22 +1,22 @@
 package com.tdns.toks.core.domain.quiz.model.dto;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@RequiredArgsConstructor
 public class UserQuizHistoryDto {
 
-	private Long userQuizHistoryId;
-	private String answer;
-	private Long likeNumber;
-	private UserSimpleDTO creator;
+	private final Long userQuizHistoryId;
+	private final String answer;
+	private final Long likeNumber;
+	private final UserSimpleDTO creator;
 
 	@Getter
-	@NoArgsConstructor
+	@RequiredArgsConstructor
 	public static class UserSimpleDTO {
-		private Long userId;
-		private String nickname;
-		private String profileImageUrl;
+		private final Long userId;
+		private final String nickname;
+		private final String profileImageUrl;
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/model/entity/Quiz.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/model/entity/Quiz.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -31,6 +33,7 @@ public class Quiz extends BaseTimeEntity {
 	private String quiz;
 
 	@Column(nullable = false, columnDefinition = "VARCHAR(10) COMMENT '퀴즈 타입'")
+	@Enumerated(EnumType.STRING)
 	private QuizType quizType;
 
 	@Column(columnDefinition = "VARCHAR(255) COMMENT '퀴즈 설명'")

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryCustomRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryCustomRepository.java
@@ -1,0 +1,11 @@
+package com.tdns.toks.core.domain.quiz.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.tdns.toks.core.domain.quiz.model.dto.UserQuizHistoryDto;
+
+public interface UserQuizHistoryCustomRepository {
+	List<UserQuizHistoryDto> retrieveByQuizId(final Long quizId, final Pageable pageable);
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryCustomRepositoryImpl.java
@@ -1,0 +1,77 @@
+package com.tdns.toks.core.domain.quiz.repository;
+
+import static com.tdns.toks.core.domain.quiz.model.entity.QQuizLike.*;
+import static com.tdns.toks.core.domain.quiz.model.entity.QUserQuizHistory.*;
+import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tdns.toks.core.domain.quiz.model.dto.UserQuizHistoryDto;
+import com.tdns.toks.core.domain.quiz.model.entity.UserQuizHistory;
+import com.tdns.toks.core.domain.user.type.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserQuizHistoryCustomRepositoryImpl implements UserQuizHistoryCustomRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<UserQuizHistoryDto> retrieveByQuizId(final Long quizId, final Pageable pageable) {
+		return jpaQueryFactory.select(
+				Projections.fields(UserQuizHistoryDto.class,
+					userQuizHistory.id.as("userQuizHistoryId"),
+					userQuizHistory.answer.as("answer"),
+					userQuizHistory.count().as("likeNumber"),
+					Projections.fields(UserQuizHistoryDto.UserSimpleDTO.class,
+						user.id.as("userId"),
+						user.nickname.as("nickname"),
+						user.profileImageUrl.as("profileImageUrl")
+					).as("creator")
+				)
+			)
+			.from(userQuizHistory)
+			.where(userQuizHistory.quizId.eq(quizId)
+				.and(user.status.eq(UserStatus.ACTIVE)))
+			.innerJoin(user)
+			.on(userQuizHistory.createdBy.eq(user.id))
+			.innerJoin(quizLike)
+			.on(userQuizHistory.id.eq(quizLike.userQuizHistoryId))
+			.orderBy(getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
+			.groupBy(userQuizHistory.id)
+			.fetch();
+	}
+
+	private List<OrderSpecifier> getOrderSpecifier(Sort sort) {
+		List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+		sort.forEach(order -> {
+				Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+				String prop = order.getProperty();
+
+				if (prop.equals("likeNumber")) {
+					orderSpecifiers.add(getNumberLikeOrderSpecifier(direction));
+					return;
+				}
+
+				PathBuilder orderByExpression = new PathBuilder(UserQuizHistory.class, "userQuizHistory");
+				orderSpecifiers.add(new OrderSpecifier(direction, orderByExpression.get(prop)));
+			});
+		return orderSpecifiers;
+	}
+
+	private OrderSpecifier getNumberLikeOrderSpecifier(Order order) {
+		if (order == Order.ASC) {
+			return userQuizHistory.count().asc();
+		}
+		return userQuizHistory.count().desc();
+	}
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryCustomRepositoryImpl.java
@@ -46,6 +46,7 @@ public class UserQuizHistoryCustomRepositoryImpl implements UserQuizHistoryCusto
 			.on(userQuizHistory.createdBy.eq(user.id))
 			.innerJoin(quizLike)
 			.on(userQuizHistory.id.eq(quizLike.userQuizHistoryId))
+			.orderBy(userQuizHistory.count().desc())
 			.orderBy(getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
 			.groupBy(userQuizHistory.id)
 			.fetch();
@@ -56,11 +57,6 @@ public class UserQuizHistoryCustomRepositoryImpl implements UserQuizHistoryCusto
 		sort.forEach(order -> {
 				Order direction = order.isAscending() ? Order.ASC : Order.DESC;
 				String prop = order.getProperty();
-
-				if (prop.equals("likeNumber")) {
-					orderSpecifiers.add(getNumberLikeOrderSpecifier(direction));
-					return;
-				}
 
 				PathBuilder orderByExpression = new PathBuilder(UserQuizHistory.class, "userQuizHistory");
 				orderSpecifiers.add(new OrderSpecifier(direction, orderByExpression.get(prop)));

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/UserQuizHistoryRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tdns.toks.core.domain.quiz.model.entity.UserQuizHistory;
 
-public interface UserQuizHistoryRepository extends JpaRepository<UserQuizHistory, Long> {
+public interface UserQuizHistoryRepository extends JpaRepository<UserQuizHistory, Long>, UserQuizHistoryCustomRepository {
 	Boolean existsByQuizIdAndCreatedBy(Long quizId, Long createdBy);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/UserQuizHistoryService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/UserQuizHistoryService.java
@@ -1,10 +1,14 @@
 package com.tdns.toks.core.domain.quiz.service;
 
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tdns.toks.core.common.exception.ApplicationErrorType;
 import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
+import com.tdns.toks.core.domain.quiz.model.dto.UserQuizHistoryDto;
 import com.tdns.toks.core.domain.quiz.model.entity.UserQuizHistory;
 import com.tdns.toks.core.domain.quiz.repository.UserQuizHistoryRepository;
 
@@ -30,4 +34,9 @@ public class UserQuizHistoryService {
 			throw new SilentApplicationErrorException(ApplicationErrorType.ALREADY_SUBMITTED_USER_QUIZ);
 		}
 	}
+
+	public List<UserQuizHistoryDto> getAllByQuizId(final Long quizId, final Pageable pageable) {
+		return userQuizHistoryRepository.retrieveByQuizId(quizId, pageable);
+	}
+
 }


### PR DESCRIPTION
## ✔️ PR 타입
- 기능

## 📃 개요
- 답변 다건 조회 API 구현하였습니다.
- #37 에서 이어지는 PR 입니다.
- [API 스펙](https://www.notion.so/depromeet/API-b3066238124e43e6b836030ce109f0f0#2027ba289219480f974c2b23edd20dc1)

## ✏️ 변경사항
### 답변 다건 조회 API 구현
- 답변, 사용자, 답변 좋아요 테이블을 inner join 합니다.
- 답변 id로 group by 합니다. (각 답변 마다 좋아요 개수 확인)
- Pageable 에서 정렬 prop을 가지고 와서 sorting 합니다.
  - 좋아요 개수로 sorting 하고 싶은 경우, 좋아요 개수는 답변 테이블에 존재하지 않는 컬럼이기 때문에 하드 코딩하여 처리하였습니다.🥲
  - GET /user-quiz-histories//quizzes/{quizId}?sort=likeNumber,asc

## 🫥 TODO
