### PR TITLE
#32 퀴즈 단건 조회 API

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
@@ -1,5 +1,7 @@
 package com.tdns.toks.api.domain.quiz.controller;
 
+import static com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.*;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizSimpleResponse;
 import com.tdns.toks.api.domain.quiz.service.QuizApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
 
@@ -39,6 +40,22 @@ public class QuizController {
 		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
 	public ResponseEntity<QuizSimpleResponse> getById(@PathVariable final Long quizId) {
 		var response = quizApiService.getById(quizId);
+		return ResponseDto.ok(response);
+	}
+
+	@GetMapping("/studies/{studyId}")
+	@Operation(
+		method = "Get",
+		summary = "퀴즈 다건 조회"
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = QuizzesResponse.class))}),
+		@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+		@ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
+		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
+	public ResponseEntity<QuizzesResponse> getAllByStudyID(@PathVariable final Long studyId) {
+		var response = quizApiService.getAllByStudyId(studyId);
 		return ResponseDto.ok(response);
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO;
 import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizSimpleResponse;
 import com.tdns.toks.api.domain.quiz.service.QuizApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
@@ -38,7 +37,7 @@ public class QuizController {
 		@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
 		@ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
 		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
-	public ResponseEntity<QuizApiDTO.QuizSimpleResponse> getById(@PathVariable final Long quizId) {
+	public ResponseEntity<QuizSimpleResponse> getById(@PathVariable final Long quizId) {
 		var response = quizApiService.getById(quizId);
 		return ResponseDto.ok(response);
 	}

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
@@ -7,7 +7,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizResponse;
+import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO;
+import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizSimpleResponse;
 import com.tdns.toks.api.domain.quiz.service.QuizApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
 
@@ -29,15 +30,15 @@ public class QuizController {
 	@GetMapping("/{quizId}")
 	@Operation(
 		method = "Get",
-		summary = "퀴즈 답변 단건 조회"
+		summary = "퀴즈 단건 조회"
 	)
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = QuizResponse.class))}),
+		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = QuizSimpleResponse.class))}),
 		@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
 		@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
 		@ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
 		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
-	public ResponseEntity<QuizResponse> getAllByQuizId(@PathVariable final Long quizId) {
+	public ResponseEntity<QuizApiDTO.QuizSimpleResponse> getById(@PathVariable final Long quizId) {
 		var response = quizApiService.getById(quizId);
 		return ResponseDto.ok(response);
 	}

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
@@ -1,0 +1,44 @@
+package com.tdns.toks.api.domain.quiz.controller;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizResponse;
+import com.tdns.toks.api.domain.quiz.service.QuizApiService;
+import com.tdns.toks.core.common.model.dto.ResponseDto;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "QuizController-V1", description = "QUIZ API")
+@RestController
+@RequestMapping(path = "/api/v1/quizzes", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequiredArgsConstructor
+public class QuizController {
+	private final QuizApiService quizApiService;
+
+	@GetMapping("/{quizId}")
+	@Operation(
+		method = "Get",
+		summary = "퀴즈 답변 단건 조회"
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = QuizResponse.class))}),
+		@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+		@ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
+		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
+	public ResponseEntity<QuizResponse> getAllByQuizId(@PathVariable final Long quizId) {
+		var response = quizApiService.getById(quizId);
+		return ResponseDto.ok(response);
+	}
+}

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
@@ -5,7 +5,9 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
+import com.tdns.toks.core.domain.quiz.type.QuizStatusType;
 import com.tdns.toks.core.domain.quiz.type.QuizType;
 import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
 
@@ -39,6 +41,7 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "duration of second", description = "duration of second")
 		private final Long durationOfSecond;
 
+		@JsonFormat(timezone = "Asia/Seoul")
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "timestamp", description = "timestamp")
 		private final Timestamp timestamp;
 
@@ -63,7 +66,7 @@ public class QuizApiDTO {
 				new Timestamp(System.currentTimeMillis()),
 				quizSimpleDTO.getImageUrls(),
 				quizSimpleDTO.getCreator(),
-				quizSimpleDTO.getQuizId()
+				quizSimpleDTO.getStudyId()
 			);
 		}
 	}
@@ -93,20 +96,24 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "duration of second", description = "duration of second")
 		private final Long durationOfSecond;
 
+		@JsonFormat(timezone = "Asia/Seoul")
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "timestamp", description = "timestamp")
 		private final Timestamp timestamp;
-
-		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "image urls", description = "image urls")
-		private final List<String> imageUrls;
 
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "creator", description = "creator")
 		private final UserSimpleDTO creator;
 
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "unSubmitters", description = "unSubmitters")
+		private final List<UserSimpleDTO> unSubmitters;
+
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
 		private final Long studyId;
 
-		public static QuizSimpleResponse toResponse(QuizSimpleDTO quizSimpleDTO) {
-			return new QuizSimpleResponse(
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
+		private final QuizStatusType quizStatus;
+
+		public static QuizResponse toResponse(QuizSimpleDTO quizSimpleDTO, List<UserSimpleDTO> unSubmitter, QuizStatusType quizStatus) {
+			return new QuizResponse(
 				quizSimpleDTO.getQuizId(),
 				quizSimpleDTO.getQuiz(),
 				quizSimpleDTO.getQuizType(),
@@ -115,10 +122,19 @@ public class QuizApiDTO {
 				quizSimpleDTO.getEndedAt(),
 				Duration.between(quizSimpleDTO.getStartedAt(), quizSimpleDTO.getEndedAt()).getSeconds(),
 				new Timestamp(System.currentTimeMillis()),
-				quizSimpleDTO.getImageUrls(),
 				quizSimpleDTO.getCreator(),
-				quizSimpleDTO.getQuizId()
+				unSubmitter,
+				quizSimpleDTO.getStudyId(),
+				quizStatus
 			);
 		}
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	@Schema(name = "QuizResponse", description = "QUIZ 조회 응답 모델")
+	public static class QuizzesResponse {
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quizzes response", description = "quizzes response")
+		private final List<QuizResponse> quizzes;
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
@@ -1,0 +1,70 @@
+package com.tdns.toks.api.domain.quiz.model.dto;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
+import com.tdns.toks.core.domain.quiz.type.QuizType;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class QuizApiDTO {
+	@Getter
+	@RequiredArgsConstructor
+	@Schema(name = "QuizResponse", description = "QUIZ 단일 조회 응답 모델")
+	public static class QuizResponse {
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz id", description = "quiz id")
+		private final Long quizId;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz", description = "quiz")
+		private final String quiz;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz type", description = "quiz type")
+		private final QuizType quizType;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "description", description = "description")
+		private final String description;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "started at", description = "started at")
+		private final LocalDateTime startedAt;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "ended at", description = "ended at")
+		private final LocalDateTime endedAt;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "duration of second", description = "duration of second")
+		private final Long durationOfSecond;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "timestamp", description = "timestamp")
+		private final Timestamp timestamp;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "image urls", description = "image urls")
+		private final List<String> imageUrls;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "creator", description = "creator")
+		private final UserSimpleDTO creator;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
+		private final Long studyId;
+
+		public static QuizResponse toResponse(QuizSimpleDTO quizSimpleDTO) {
+			return new QuizResponse(
+				quizSimpleDTO.getQuizId(),
+				quizSimpleDTO.getQuiz(),
+				quizSimpleDTO.getQuizType(),
+				quizSimpleDTO.getDescription(),
+				quizSimpleDTO.getStartedAt(),
+				quizSimpleDTO.getEndedAt(),
+				Duration.between(quizSimpleDTO.getStartedAt(), quizSimpleDTO.getEndedAt()).getSeconds(),
+				new Timestamp(System.currentTimeMillis()),
+				quizSimpleDTO.getImageUrls(),
+				quizSimpleDTO.getCreator(),
+				quizSimpleDTO.getQuizId()
+			);
+		}
+	}
+}

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
@@ -16,7 +16,61 @@ import lombok.RequiredArgsConstructor;
 public class QuizApiDTO {
 	@Getter
 	@RequiredArgsConstructor
-	@Schema(name = "QuizResponse", description = "QUIZ 단일 조회 응답 모델")
+	@Schema(name = "QuizSimpleResponse", description = "QUIZ 단일 조회 응답 모델")
+	public static class QuizSimpleResponse {
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz id", description = "quiz id")
+		private final Long quizId;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz", description = "quiz")
+		private final String quiz;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz type", description = "quiz type")
+		private final QuizType quizType;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "description", description = "description")
+		private final String description;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "started at", description = "started at")
+		private final LocalDateTime startedAt;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "ended at", description = "ended at")
+		private final LocalDateTime endedAt;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "duration of second", description = "duration of second")
+		private final Long durationOfSecond;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "timestamp", description = "timestamp")
+		private final Timestamp timestamp;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "image urls", description = "image urls")
+		private final List<String> imageUrls;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "creator", description = "creator")
+		private final UserSimpleDTO creator;
+
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
+		private final Long studyId;
+
+		public static QuizSimpleResponse toResponse(QuizSimpleDTO quizSimpleDTO) {
+			return new QuizSimpleResponse(
+				quizSimpleDTO.getQuizId(),
+				quizSimpleDTO.getQuiz(),
+				quizSimpleDTO.getQuizType(),
+				quizSimpleDTO.getDescription(),
+				quizSimpleDTO.getStartedAt(),
+				quizSimpleDTO.getEndedAt(),
+				Duration.between(quizSimpleDTO.getStartedAt(), quizSimpleDTO.getEndedAt()).getSeconds(),
+				new Timestamp(System.currentTimeMillis()),
+				quizSimpleDTO.getImageUrls(),
+				quizSimpleDTO.getCreator(),
+				quizSimpleDTO.getQuizId()
+			);
+		}
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	@Schema(name = "QuizResponse", description = "QUIZ 조회 응답 모델")
 	public static class QuizResponse {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz id", description = "quiz id")
 		private final Long quizId;
@@ -51,8 +105,8 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
 		private final Long studyId;
 
-		public static QuizResponse toResponse(QuizSimpleDTO quizSimpleDTO) {
-			return new QuizResponse(
+		public static QuizSimpleResponse toResponse(QuizSimpleDTO quizSimpleDTO) {
+			return new QuizSimpleResponse(
 				quizSimpleDTO.getQuizId(),
 				quizSimpleDTO.getQuiz(),
 				quizSimpleDTO.getQuizType(),

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizLikeApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizLikeApiDTO.java
@@ -6,33 +6,28 @@ import com.tdns.toks.core.domain.quiz.model.entity.QuizLike;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 
 public class QuizLikeApiDTO {
-	@Builder
 	@Getter
-	@Setter
 	@AllArgsConstructor
-	@NoArgsConstructor
 	@Schema(name = "QuizLikeRequest", description = "USER QUIZ LIKE 생성 요청 모델")
 	public static class QuizLikeRequest {
 		@NotEmpty(message = "퀴즈 답변 id는 필수 항목입니다.")
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz reply history id", description = "quiz reply history id")
-		private Long quizReplyHistoryId;
+		private final Long quizReplyHistoryId;
 	}
 
-	@AllArgsConstructor
-	@NoArgsConstructor
+	@Getter
+	@RequiredArgsConstructor
 	@Schema(name = "QuizLikeResponse", description = "QUIZ LIKE 생성 응답 모델")
 	public static class QuizLikeResponse {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "user quiz like id", description = "user quiz like id")
-		private Long quizLikeId;
+		private final Long quizLikeId;
 
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz reply history id", description = "quiz reply history id")
-		private Long quizReplyHistoryId;
+		private final Long quizReplyHistoryId;
 
 		public static QuizLikeResponse toResponse(QuizLike quizLike) {
 			return new QuizLikeResponse(

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizReplyHistoryApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizReplyHistoryApiDTO.java
@@ -8,9 +8,8 @@ import com.tdns.toks.core.domain.quiz.model.dto.QuizReplyHistoryDto;
 import com.tdns.toks.core.domain.quiz.model.entity.QuizReplyHistory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 public class QuizReplyHistoryApiDTO {
 	@Getter
@@ -24,18 +23,18 @@ public class QuizReplyHistoryApiDTO {
 		private Long quizId;
 	}
 
-	@AllArgsConstructor
-	@NoArgsConstructor
+	@Getter
+	@RequiredArgsConstructor
 	@Schema(name = "QuizReplyHistoryRequest", description = "QUIZ REPLY HISTORY 생성 응답 모델")
 	public static class QuizReplyHistoryResponse {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz reply history id", description = "quiz reply history id")
-		private Long quizReplyHistoryId;
+		private final Long quizReplyHistoryId;
 
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "answer", description = "댭변")
-		private String answer;
+		private final String answer;
 
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz id", description = "quiz id")
-		private Long quizId;
+		private final Long quizId;
 
 		public static QuizReplyHistoryResponse toResponse(QuizReplyHistory quizReplyHistory) {
 			return new QuizReplyHistoryResponse(
@@ -47,11 +46,10 @@ public class QuizReplyHistoryApiDTO {
 	}
 
 	@Getter
-	@AllArgsConstructor
-	@NoArgsConstructor
+	@RequiredArgsConstructor
 	@Schema(name = "QuizReplyHistoriesResponse", description = "QUIZ REPLY HISTORY 생성 응답 모델")
 	public static class QuizReplyHistoriesResponse {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quiz reply history 리스트", description = "quiz reply history 리스트")
-		private List<QuizReplyHistoryDto> quizReplyHistories;
+		private final List<QuizReplyHistoryDto> quizReplyHistories;
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
@@ -1,0 +1,20 @@
+package com.tdns.toks.api.domain.quiz.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizResponse;
+import com.tdns.toks.core.domain.quiz.service.QuizService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizApiService {
+	private final QuizService quizService;
+
+	public QuizResponse getById(final Long id) {
+		return QuizResponse.toResponse(quizService.retrieveByIdOrThrow(id));
+	}
+}

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
@@ -1,10 +1,15 @@
 package com.tdns.toks.api.domain.quiz.service;
 
+import static com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.*;
+
+import java.util.ArrayList;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizSimpleResponse;
+import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 import com.tdns.toks.core.domain.quiz.service.QuizService;
+import com.tdns.toks.core.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,8 +18,31 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class QuizApiService {
 	private final QuizService quizService;
+	private final UserService userService;
 
 	public QuizSimpleResponse getById(final Long id) {
 		return QuizSimpleResponse.toResponse(quizService.retrieveByIdOrThrow(id));
 	}
+
+	public QuizzesResponse getAllByStudyId(final Long studyId) {
+		var unSubmitters = userService.filterUnSubmitterByStudyId(studyId);
+		var quizzes = quizService.retrieveByStudyId(studyId);
+		var results = new ArrayList<QuizResponse>();
+
+		for (QuizSimpleDTO quiz : quizzes) {
+			var unSubmitter = unSubmitters.stream()
+				.filter(userSimpleByQuizIdDTO -> userSimpleByQuizIdDTO.getQuizId().equals(quiz.getQuizId()))
+				.findFirst()
+				.get()
+				.getUsers();
+			results.add(QuizResponse.toResponse(
+				quiz,
+				unSubmitter,
+				quizService.getQuizStatus(quiz.getStartedAt(), quiz.getEndedAt()))
+			);
+		}
+
+		return new QuizzesResponse(results);
+	}
+
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
@@ -3,7 +3,7 @@ package com.tdns.toks.api.domain.quiz.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizResponse;
+import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizSimpleResponse;
 import com.tdns.toks.core.domain.quiz.service.QuizService;
 
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 public class QuizApiService {
 	private final QuizService quizService;
 
-	public QuizResponse getById(final Long id) {
-		return QuizResponse.toResponse(quizService.retrieveByIdOrThrow(id));
+	public QuizSimpleResponse getById(final Long id) {
+		return QuizSimpleResponse.toResponse(quizService.retrieveByIdOrThrow(id));
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quizrank/model/dto/QuizRankApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quizrank/model/dto/QuizRankApiDTO.java
@@ -5,20 +5,15 @@ import java.util.List;
 import com.tdns.toks.core.domain.quizrank.model.dto.QuizRankDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 
 public class QuizRankApiDTO {
-
-	@AllArgsConstructor
-	@NoArgsConstructor
 	@Getter
-	@Setter
+	@RequiredArgsConstructor
 	@Schema(name = "QuizRanksApiResponse", description = "Ranks 응답 모델")
 	public static class QuizRanksApiResponse {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "ranks", description = "rank 리스트")
-		private List<QuizRankDTO> quizRanksDto;
+		private final List<QuizRankDTO> quizRanksDto;
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/QuizReplyHistoryDto.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/QuizReplyHistoryDto.java
@@ -1,22 +1,14 @@
 package com.tdns.toks.core.domain.quiz.model.dto;
 
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class QuizReplyHistoryDto {
 
-	private final Long quizReplyHistoryId;
-	private final String answer;
-	private final Long likeNumber;
-	private final UserSimpleDTO creator;
-
-	@Getter
-	@RequiredArgsConstructor
-	public static class UserSimpleDTO {
-		private final Long userId;
-		private final String nickname;
-		private final String profileImageUrl;
-	}
+	private Long quizReplyHistoryId;
+	private String answer;
+	private Long likeNumber;
+	private UserSimpleDTO creator;
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/QuizSimpleDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/QuizSimpleDTO.java
@@ -1,0 +1,30 @@
+package com.tdns.toks.core.domain.quiz.model.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.tdns.toks.core.domain.quiz.type.QuizType;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+
+import lombok.Getter;
+
+@Getter
+public class QuizSimpleDTO {
+	private Long quizId;
+
+	private String quiz;
+
+	private QuizType quizType;
+
+	private String description;
+
+	private LocalDateTime startedAt;
+
+	private LocalDateTime endedAt;
+
+	private List<String> imageUrls;
+
+	private UserSimpleDTO creator;
+
+	private Long studyId;
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepository.java
@@ -1,9 +1,12 @@
 package com.tdns.toks.core.domain.quiz.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 
 public interface QuizCustomRepository {
 	Optional<QuizSimpleDTO> retrieveById(Long id);
+
+	List<QuizSimpleDTO> retrieveByStudyId(Long studyId);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepository.java
@@ -1,0 +1,9 @@
+package com.tdns.toks.core.domain.quiz.repository;
+
+import java.util.Optional;
+
+import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
+
+public interface QuizCustomRepository {
+	Optional<QuizSimpleDTO> retrieveById(Long id);
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.tdns.toks.core.domain.quiz.repository;
+
+import static com.tdns.toks.core.domain.quiz.model.entity.QQuiz.*;
+import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
+
+import java.util.Optional;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class QuizCustomRepositoryImpl implements QuizCustomRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public Optional<QuizSimpleDTO> retrieveById(Long id) {
+		return Optional.ofNullable(jpaQueryFactory.select(
+				Projections.fields(QuizSimpleDTO.class,
+					quiz1.id.as("quizId"),
+					quiz1.quiz.as("quiz"),
+					quiz1.quizType.as("quizType"),
+					quiz1.description.as("description"),
+					quiz1.startedAt.as("startedAt"),
+					quiz1.endedAt.as("endedAt"),
+					quiz1.imageUrls.as("imageUrls"),
+					quiz1.studyId.as("studyId"),
+					Projections.fields(UserSimpleDTO.class,
+						user.id.as("userId"),
+						user.nickname.as("nickname"),
+						user.profileImageUrl.as("profileImageUrl")
+					).as("creator")
+				)
+			)
+			.from(quiz1)
+			.where(quiz1.id.eq(id))
+			.innerJoin(user)
+			.on(quiz1.createdBy.eq(user.id))
+			.fetchOne());
+	}
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.tdns.toks.core.domain.quiz.repository;
 import static com.tdns.toks.core.domain.quiz.model.entity.QQuiz.*;
 import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.querydsl.core.types.Projections;
@@ -40,5 +41,31 @@ public class QuizCustomRepositoryImpl implements QuizCustomRepository {
 			.innerJoin(user)
 			.on(quiz1.createdBy.eq(user.id))
 			.fetchOne());
+	}
+
+	@Override
+	public List<QuizSimpleDTO> retrieveByStudyId(Long studyId) {
+		return jpaQueryFactory.select(
+				Projections.fields(QuizSimpleDTO.class,
+					quiz1.id.as("quizId"),
+					quiz1.quiz.as("quiz"),
+					quiz1.quizType.as("quizType"),
+					quiz1.description.as("description"),
+					quiz1.startedAt.as("startedAt"),
+					quiz1.endedAt.as("endedAt"),
+					quiz1.imageUrls.as("imageUrls"),
+					quiz1.studyId.as("studyId"),
+					Projections.fields(UserSimpleDTO.class,
+						user.id.as("userId"),
+						user.nickname.as("nickname"),
+						user.profileImageUrl.as("profileImageUrl")
+					).as("creator")
+				)
+			)
+			.from(quiz1)
+			.where(quiz1.studyId.eq(studyId))
+			.innerJoin(user)
+			.on(quiz1.createdBy.eq(user.id))
+			.fetch();
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizReplyHistoryCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizReplyHistoryCustomRepositoryImpl.java
@@ -17,6 +17,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tdns.toks.core.domain.quiz.model.dto.QuizReplyHistoryDto;
 import com.tdns.toks.core.domain.quiz.model.entity.QuizReplyHistory;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
 import com.tdns.toks.core.domain.user.type.UserStatus;
 
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,7 @@ public class QuizReplyHistoryCustomRepositoryImpl implements QuizReplyHistoryCus
 					quizReplyHistory.id.as("quizReplyHistoryId"),
 					quizReplyHistory.answer.as("answer"),
 					quizReplyHistory.count().as("likeNumber"),
-					Projections.fields(QuizReplyHistoryDto.UserSimpleDTO.class,
+					Projections.fields(UserSimpleDTO.class,
 						user.id.as("userId"),
 						user.nickname.as("nickname"),
 						user.profileImageUrl.as("profileImageUrl")

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tdns.toks.core.domain.quiz.model.entity.Quiz;
 
-public interface QuizRepository extends JpaRepository<Quiz, Long> {
+public interface QuizRepository extends JpaRepository<Quiz, Long>, QuizCustomRepository {
 
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
@@ -1,5 +1,8 @@
 package com.tdns.toks.core.domain.quiz.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -8,6 +11,7 @@ import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
 import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 import com.tdns.toks.core.domain.quiz.model.entity.Quiz;
 import com.tdns.toks.core.domain.quiz.repository.QuizRepository;
+import com.tdns.toks.core.domain.quiz.type.QuizStatusType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,5 +29,20 @@ public class QuizService {
 	public QuizSimpleDTO retrieveByIdOrThrow(final Long id) {
 		return quizRepository.retrieveById(id)
 			.orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.INVALID_REQUEST));
+	}
+
+	public List<QuizSimpleDTO> retrieveByStudyId(final Long studyId) {
+		return quizRepository.retrieveByStudyId(studyId);
+	}
+
+	public QuizStatusType getQuizStatus(final LocalDateTime startedAt, final LocalDateTime endedAt) {
+		LocalDateTime now = LocalDateTime.now();
+
+		if (now.isBefore(startedAt)) {
+			return QuizStatusType.TO_DO;
+		} else if (now.isAfter(endedAt)) {
+			return QuizStatusType.DONE;
+		}
+		return QuizStatusType.IN_PROGRESS;
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.tdns.toks.core.common.exception.ApplicationErrorType;
 import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
+import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 import com.tdns.toks.core.domain.quiz.model.entity.Quiz;
 import com.tdns.toks.core.domain.quiz.repository.QuizRepository;
 
@@ -18,6 +19,11 @@ public class QuizService {
 
 	public Quiz getOrThrow(final Long id) {
 		return quizRepository.findById(id)
+			.orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.INVALID_REQUEST));
+	}
+
+	public QuizSimpleDTO retrieveByIdOrThrow(final Long id) {
+		return quizRepository.retrieveById(id)
 			.orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.INVALID_REQUEST));
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/type/QuizStatusType.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/type/QuizStatusType.java
@@ -1,0 +1,14 @@
+package com.tdns.toks.core.domain.quiz.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum QuizStatusType {
+
+	TO_DO,			// 퀴즈 시작 전
+	IN_PROGRESS,	// 퀴즈 진행 중
+	DONE			// 퀴즈 종료
+	;
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/dto/QuizRankDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/dto/QuizRankDTO.java
@@ -1,21 +1,13 @@
 package com.tdns.toks.core.domain.quizrank.model.dto;
 
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class QuizRankDTO {
 
 	private Long quizRankId;
 	private Integer score;
 	private UserSimpleDTO user;
-
-	@Getter
-	@NoArgsConstructor
-	public static class UserSimpleDTO {
-		private Long userId;
-		private String nickname;
-		private String profileImageUrl;
-	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/CustomQuizRankRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/CustomQuizRankRepositoryImpl.java
@@ -8,6 +8,7 @@ import java.util.List;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tdns.toks.core.domain.quizrank.model.dto.QuizRankDTO;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
 import com.tdns.toks.core.domain.user.type.UserStatus;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class CustomQuizRankRepositoryImpl implements CustomQuizRankRepository {
 				Projections.fields(QuizRankDTO.class,
 					quizRank.id.as("quizRankId"),
 					quizRank.score.as("score"),
-					Projections.fields(QuizRankDTO.UserSimpleDTO.class,
+					Projections.fields(UserSimpleDTO.class,
 						user.id.as("userId"),
 						user.nickname.as("nickname"),
 						user.profileImageUrl.as("profileImageUrl")

--- a/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleByQuizIdDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleByQuizIdDTO.java
@@ -1,0 +1,15 @@
+package com.tdns.toks.core.domain.user.model.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserSimpleByQuizIdDTO {
+	private Long quizId;
+	private List<UserSimpleDTO> users;
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleDTO.java
@@ -1,8 +1,10 @@
 package com.tdns.toks.core.domain.user.model.dto;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 public class UserSimpleDTO {
 	private Long userId;
 	private String nickname;

--- a/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleDTO.java
@@ -1,0 +1,10 @@
+package com.tdns.toks.core.domain.user.model.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserSimpleDTO {
+	private Long userId;
+	private String nickname;
+	private String profileImageUrl;
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepository.java
@@ -1,0 +1,12 @@
+package com.tdns.toks.core.domain.user.repository;
+
+import java.util.List;
+
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleByQuizIdDTO;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+
+public interface UserCustomRepository {
+	List<UserSimpleByQuizIdDTO> retrieveSubmittedByStudyId(Long studyId);
+
+	List<UserSimpleDTO> retrieveParticipantByStudyId(Long studyId);
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.tdns.toks.core.domain.user.repository;
+
+import static com.querydsl.core.group.GroupBy.*;
+import static com.tdns.toks.core.domain.quiz.model.entity.QQuiz.*;
+import static com.tdns.toks.core.domain.quiz.model.entity.QQuizReplyHistory.*;
+import static com.tdns.toks.core.domain.quizrank.model.entity.QQuizRank.*;
+import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleByQuizIdDTO;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+import com.tdns.toks.core.domain.user.type.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<UserSimpleByQuizIdDTO> retrieveSubmittedByStudyId(Long studyId) {
+		return new ArrayList<>(
+			jpaQueryFactory
+				.from(user)
+				.where(quizRank.studyId.eq(studyId)
+					.and(user.status.eq(UserStatus.ACTIVE))
+					.and(quiz1.studyId.eq(studyId)))
+				.innerJoin(quizRank)
+				.on(quizRank.userId.eq(user.id))
+				.innerJoin(quizReplyHistory)
+				.on(quizReplyHistory.createdBy.eq(user.id))
+				.innerJoin(quiz1)
+				.on(quiz1.id.eq(quizReplyHistory.quizId))
+				.transform(groupBy(quizReplyHistory.quizId).as(
+					Projections.fields(UserSimpleByQuizIdDTO.class,
+						quizReplyHistory.quizId.as("quizId"),
+						list(Projections.fields(UserSimpleDTO.class,
+							user.id.as("userId"),
+							user.nickname.as("nickname"),
+							user.profileImageUrl.as("profileImageUrl")
+						)).as("users")
+					)
+				)).values()
+		);
+	}
+
+	@Override
+	public List<UserSimpleDTO> retrieveParticipantByStudyId(Long studyId) {
+		return jpaQueryFactory
+			.select(
+				Projections.fields(UserSimpleDTO.class,
+					user.id.as("userId"),
+					user.nickname.as("nickname"),
+					user.profileImageUrl.as("profileImageUrl")))
+			.from(user)
+			.where(quizRank.studyId.eq(studyId)
+				.and(user.status.eq(UserStatus.ACTIVE)))
+			.innerJoin(quizRank)
+			.on(quizRank.userId.eq(user.id))
+			.fetch();
+	}
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserRepository.java
@@ -1,16 +1,16 @@
 package com.tdns.toks.core.domain.user.repository;
 
-import com.tdns.toks.core.domain.user.model.entity.User;
-import com.tdns.toks.core.domain.user.type.UserProvider;
-import com.tdns.toks.core.domain.user.type.UserStatus;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.tdns.toks.core.domain.user.model.entity.User;
+import com.tdns.toks.core.domain.user.type.UserProvider;
+import com.tdns.toks.core.domain.user.type.UserStatus;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
     Optional<User> findByEmail(String email);
 
     boolean existsByNickname(String Nickname);


### PR DESCRIPTION
## ✔️ PR 타입
- 기능

## 📃 개요
- 퀴즈 단건 조회 API 구현하였습니다.
- [API 스펙](https://www.notion.so/depromeet/API-b3066238124e43e6b836030ce109f0f0#2027ba289219480f974c2b23edd20dc1)

## ✏️ 변경사항
### 퀴즈 단건 조회 API
- quizId로 퀴즈를 조회합니다.

### UserSimpleDTO 생성
- 공통으로 사용되는 사용자 간단 정보 클래스 생성
```
        "userId": 1,
        "nickname": "test",
        "profileImageUrl": "test"
```
### Projections.fields 사용되는 DTO 에 final 삭제
- 필드 주입으로 dto 생성 시에 기본 생성자가 있어야 생성이 됩니다🥲

## 🫥 TODO
- 퀴즈 다건 조회 API