### PR TITLE
#32 퀴즈 다건 조회 API

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizController.java
@@ -1,5 +1,7 @@
 package com.tdns.toks.api.domain.quiz.controller;
 
+import static com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.*;
+
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -7,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizSimpleResponse;
 import com.tdns.toks.api.domain.quiz.service.QuizApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
 
@@ -39,6 +40,22 @@ public class QuizController {
 		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
 	public ResponseEntity<QuizSimpleResponse> getById(@PathVariable final Long quizId) {
 		var response = quizApiService.getById(quizId);
+		return ResponseDto.ok(response);
+	}
+
+	@GetMapping("/studies/{studyId}")
+	@Operation(
+		method = "Get",
+		summary = "퀴즈 다건 조회"
+	)
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = QuizzesResponse.class))}),
+		@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+		@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+		@ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
+		@ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
+	public ResponseEntity<QuizzesResponse> getAllByStudyID(@PathVariable final Long studyId) {
+		var response = quizApiService.getAllByStudyId(studyId);
 		return ResponseDto.ok(response);
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
+import com.tdns.toks.core.domain.quiz.type.QuizStatusType;
 import com.tdns.toks.core.domain.quiz.type.QuizType;
 import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
 
@@ -96,9 +97,6 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "timestamp", description = "timestamp")
 		private final Timestamp timestamp;
 
-		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "image urls", description = "image urls")
-		private final List<String> imageUrls;
-
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "creator", description = "creator")
 		private final UserSimpleDTO creator;
 
@@ -108,7 +106,10 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
 		private final Long studyId;
 
-		public static QuizResponse toResponse(QuizSimpleDTO quizSimpleDTO, List<UserSimpleDTO> unSubmitter) {
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
+		private final QuizStatusType quizStatus;
+
+		public static QuizResponse toResponse(QuizSimpleDTO quizSimpleDTO, List<UserSimpleDTO> unSubmitter, QuizStatusType quizStatus) {
 			return new QuizResponse(
 				quizSimpleDTO.getQuizId(),
 				quizSimpleDTO.getQuiz(),
@@ -118,10 +119,10 @@ public class QuizApiDTO {
 				quizSimpleDTO.getEndedAt(),
 				Duration.between(quizSimpleDTO.getStartedAt(), quizSimpleDTO.getEndedAt()).getSeconds(),
 				new Timestamp(System.currentTimeMillis()),
-				quizSimpleDTO.getImageUrls(),
 				quizSimpleDTO.getCreator(),
 				unSubmitter,
-				quizSimpleDTO.getStudyId()
+				quizSimpleDTO.getStudyId(),
+				quizStatus
 			);
 		}
 	}

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
@@ -63,7 +63,7 @@ public class QuizApiDTO {
 				new Timestamp(System.currentTimeMillis()),
 				quizSimpleDTO.getImageUrls(),
 				quizSimpleDTO.getCreator(),
-				quizSimpleDTO.getQuizId()
+				quizSimpleDTO.getStudyId()
 			);
 		}
 	}
@@ -102,11 +102,14 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "creator", description = "creator")
 		private final UserSimpleDTO creator;
 
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "unSubmitters", description = "unSubmitters")
+		private final List<UserSimpleDTO> unSubmitters;
+
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "study id", description = "study id")
 		private final Long studyId;
 
-		public static QuizSimpleResponse toResponse(QuizSimpleDTO quizSimpleDTO) {
-			return new QuizSimpleResponse(
+		public static QuizResponse toResponse(QuizSimpleDTO quizSimpleDTO, List<UserSimpleDTO> unSubmitter) {
+			return new QuizResponse(
 				quizSimpleDTO.getQuizId(),
 				quizSimpleDTO.getQuiz(),
 				quizSimpleDTO.getQuizType(),
@@ -117,8 +120,17 @@ public class QuizApiDTO {
 				new Timestamp(System.currentTimeMillis()),
 				quizSimpleDTO.getImageUrls(),
 				quizSimpleDTO.getCreator(),
-				quizSimpleDTO.getQuizId()
+				unSubmitter,
+				quizSimpleDTO.getStudyId()
 			);
 		}
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	@Schema(name = "QuizResponse", description = "QUIZ 조회 응답 모델")
+	public static class QuizzesResponse {
+		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "quizzes response", description = "quizzes response")
+		private final List<QuizResponse> quizzes;
 	}
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/model/dto/QuizApiDTO.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 import com.tdns.toks.core.domain.quiz.type.QuizStatusType;
 import com.tdns.toks.core.domain.quiz.type.QuizType;
@@ -40,6 +41,7 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "duration of second", description = "duration of second")
 		private final Long durationOfSecond;
 
+		@JsonFormat(timezone = "Asia/Seoul")
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "timestamp", description = "timestamp")
 		private final Timestamp timestamp;
 
@@ -94,6 +96,7 @@ public class QuizApiDTO {
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "duration of second", description = "duration of second")
 		private final Long durationOfSecond;
 
+		@JsonFormat(timezone = "Asia/Seoul")
 		@Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "timestamp", description = "timestamp")
 		private final Timestamp timestamp;
 

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
@@ -1,10 +1,15 @@
 package com.tdns.toks.api.domain.quiz.service;
 
+import static com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.*;
+
+import java.util.ArrayList;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tdns.toks.api.domain.quiz.model.dto.QuizApiDTO.QuizSimpleResponse;
+import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 import com.tdns.toks.core.domain.quiz.service.QuizService;
+import com.tdns.toks.core.domain.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,8 +18,27 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class QuizApiService {
 	private final QuizService quizService;
+	private final UserService userService;
 
 	public QuizSimpleResponse getById(final Long id) {
 		return QuizSimpleResponse.toResponse(quizService.retrieveByIdOrThrow(id));
 	}
+
+	public QuizzesResponse getAllByStudyId(final Long studyId) {
+		var unSubmitters = userService.filterUnSubmitterByStudyId(studyId);
+		var quizzes = quizService.retrieveByStudyId(studyId);
+		var results = new ArrayList<QuizResponse>();
+
+		for (QuizSimpleDTO quizz : quizzes) {
+			var unSubmitter = unSubmitters.stream()
+				.filter(userSimpleByQuizIdDTO -> userSimpleByQuizIdDTO.getQuizId().equals(quizz.getQuizId()))
+				.findFirst()
+				.get()
+				.getUsers();
+			results.add(QuizResponse.toResponse(quizz, unSubmitter));
+		}
+
+		return new QuizzesResponse(results);
+	}
+
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
@@ -29,13 +29,17 @@ public class QuizApiService {
 		var quizzes = quizService.retrieveByStudyId(studyId);
 		var results = new ArrayList<QuizResponse>();
 
-		for (QuizSimpleDTO quizz : quizzes) {
+		for (QuizSimpleDTO quiz : quizzes) {
 			var unSubmitter = unSubmitters.stream()
-				.filter(userSimpleByQuizIdDTO -> userSimpleByQuizIdDTO.getQuizId().equals(quizz.getQuizId()))
+				.filter(userSimpleByQuizIdDTO -> userSimpleByQuizIdDTO.getQuizId().equals(quiz.getQuizId()))
 				.findFirst()
 				.get()
 				.getUsers();
-			results.add(QuizResponse.toResponse(quizz, unSubmitter));
+			results.add(QuizResponse.toResponse(
+				quiz,
+				unSubmitter,
+				quizService.getQuizStatus(quiz.getStartedAt(), quiz.getEndedAt()))
+			);
 		}
 
 		return new QuizzesResponse(results);

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepository.java
@@ -1,9 +1,12 @@
 package com.tdns.toks.core.domain.quiz.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 
 public interface QuizCustomRepository {
 	Optional<QuizSimpleDTO> retrieveById(Long id);
+
+	List<QuizSimpleDTO> retrieveByStudyId(Long studyId);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.tdns.toks.core.domain.quiz.repository;
 import static com.tdns.toks.core.domain.quiz.model.entity.QQuiz.*;
 import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.querydsl.core.types.Projections;
@@ -40,5 +41,31 @@ public class QuizCustomRepositoryImpl implements QuizCustomRepository {
 			.innerJoin(user)
 			.on(quiz1.createdBy.eq(user.id))
 			.fetchOne());
+	}
+
+	@Override
+	public List<QuizSimpleDTO> retrieveByStudyId(Long studyId) {
+		return jpaQueryFactory.select(
+				Projections.fields(QuizSimpleDTO.class,
+					quiz1.id.as("quizId"),
+					quiz1.quiz.as("quiz"),
+					quiz1.quizType.as("quizType"),
+					quiz1.description.as("description"),
+					quiz1.startedAt.as("startedAt"),
+					quiz1.endedAt.as("endedAt"),
+					quiz1.imageUrls.as("imageUrls"),
+					quiz1.studyId.as("studyId"),
+					Projections.fields(UserSimpleDTO.class,
+						user.id.as("userId"),
+						user.nickname.as("nickname"),
+						user.profileImageUrl.as("profileImageUrl")
+					).as("creator")
+				)
+			)
+			.from(quiz1)
+			.where(quiz1.studyId.eq(studyId))
+			.innerJoin(user)
+			.on(quiz1.createdBy.eq(user.id))
+			.fetch();
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
@@ -1,5 +1,7 @@
 package com.tdns.toks.core.domain.quiz.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,5 +27,9 @@ public class QuizService {
 	public QuizSimpleDTO retrieveByIdOrThrow(final Long id) {
 		return quizRepository.retrieveById(id)
 			.orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.INVALID_REQUEST));
+	}
+
+	public List<QuizSimpleDTO> retrieveByStudyId(final Long studyId) {
+		return quizRepository.retrieveByStudyId(studyId);
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
@@ -1,5 +1,6 @@
 package com.tdns.toks.core.domain.quiz.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -10,6 +11,7 @@ import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
 import com.tdns.toks.core.domain.quiz.model.dto.QuizSimpleDTO;
 import com.tdns.toks.core.domain.quiz.model.entity.Quiz;
 import com.tdns.toks.core.domain.quiz.repository.QuizRepository;
+import com.tdns.toks.core.domain.quiz.type.QuizStatusType;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,5 +33,16 @@ public class QuizService {
 
 	public List<QuizSimpleDTO> retrieveByStudyId(final Long studyId) {
 		return quizRepository.retrieveByStudyId(studyId);
+	}
+
+	public QuizStatusType getQuizStatus(final LocalDateTime startedAt, final LocalDateTime endedAt) {
+		LocalDateTime now = LocalDateTime.now();
+
+		if (now.isBefore(startedAt)) {
+			return QuizStatusType.TO_DO;
+		} else if (now.isAfter(endedAt)) {
+			return QuizStatusType.DONE;
+		}
+		return QuizStatusType.IN_PROGRESS;
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/type/QuizStatusType.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/type/QuizStatusType.java
@@ -1,0 +1,14 @@
+package com.tdns.toks.core.domain.quiz.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum QuizStatusType {
+
+	TO_DO,			// 퀴즈 시작 전
+	IN_PROGRESS,	// 퀴즈 진행 중
+	DONE			// 퀴즈 종료
+	;
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleByQuizIdDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleByQuizIdDTO.java
@@ -1,0 +1,15 @@
+package com.tdns.toks.core.domain.user.model.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserSimpleByQuizIdDTO {
+	private Long quizId;
+	private List<UserSimpleDTO> users;
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/model/dto/UserSimpleDTO.java
@@ -1,8 +1,10 @@
 package com.tdns.toks.core.domain.user.model.dto;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@EqualsAndHashCode
 public class UserSimpleDTO {
 	private Long userId;
 	private String nickname;

--- a/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepository.java
@@ -1,0 +1,12 @@
+package com.tdns.toks.core.domain.user.repository;
+
+import java.util.List;
+
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleByQuizIdDTO;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+
+public interface UserCustomRepository {
+	List<UserSimpleByQuizIdDTO> retrieveSubmittedByStudyId(Long studyId);
+
+	List<UserSimpleDTO> retrieveParticipantByStudyId(Long studyId);
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.tdns.toks.core.domain.user.repository;
 
 import static com.querydsl.core.group.GroupBy.*;
+import static com.tdns.toks.core.domain.quiz.model.entity.QQuiz.*;
 import static com.tdns.toks.core.domain.quiz.model.entity.QQuizReplyHistory.*;
 import static com.tdns.toks.core.domain.quizrank.model.entity.QQuizRank.*;
 import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
@@ -26,11 +27,14 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
 			jpaQueryFactory
 				.from(user)
 				.where(quizRank.studyId.eq(studyId)
-					.and(user.status.eq(UserStatus.ACTIVE)))
+					.and(user.status.eq(UserStatus.ACTIVE))
+					.and(quiz1.studyId.eq(studyId)))
 				.innerJoin(quizRank)
 				.on(quizRank.userId.eq(user.id))
 				.innerJoin(quizReplyHistory)
 				.on(quizReplyHistory.createdBy.eq(user.id))
+				.innerJoin(quiz1)
+				.on(quiz1.id.eq(quizReplyHistory.quizId))
 				.transform(groupBy(quizReplyHistory.quizId).as(
 					Projections.fields(UserSimpleByQuizIdDTO.class,
 						quizReplyHistory.quizId.as("quizId"),

--- a/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserCustomRepositoryImpl.java
@@ -1,0 +1,62 @@
+package com.tdns.toks.core.domain.user.repository;
+
+import static com.querydsl.core.group.GroupBy.*;
+import static com.tdns.toks.core.domain.quiz.model.entity.QQuizReplyHistory.*;
+import static com.tdns.toks.core.domain.quizrank.model.entity.QQuizRank.*;
+import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleByQuizIdDTO;
+import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
+import com.tdns.toks.core.domain.user.type.UserStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<UserSimpleByQuizIdDTO> retrieveSubmittedByStudyId(Long studyId) {
+		return new ArrayList<>(
+			jpaQueryFactory
+				.from(user)
+				.where(quizRank.studyId.eq(studyId)
+					.and(user.status.eq(UserStatus.ACTIVE)))
+				.innerJoin(quizRank)
+				.on(quizRank.userId.eq(user.id))
+				.innerJoin(quizReplyHistory)
+				.on(quizReplyHistory.createdBy.eq(user.id))
+				.transform(groupBy(quizReplyHistory.quizId).as(
+					Projections.fields(UserSimpleByQuizIdDTO.class,
+						quizReplyHistory.quizId.as("quizId"),
+						list(Projections.fields(UserSimpleDTO.class,
+							user.id.as("userId"),
+							user.nickname.as("nickname"),
+							user.profileImageUrl.as("profileImageUrl")
+						)).as("users")
+					)
+				)).values()
+		);
+	}
+
+	@Override
+	public List<UserSimpleDTO> retrieveParticipantByStudyId(Long studyId) {
+		return jpaQueryFactory
+			.select(
+				Projections.fields(UserSimpleDTO.class,
+					user.id.as("userId"),
+					user.nickname.as("nickname"),
+					user.profileImageUrl.as("profileImageUrl")))
+			.from(user)
+			.where(quizRank.studyId.eq(studyId)
+				.and(user.status.eq(UserStatus.ACTIVE)))
+			.innerJoin(quizRank)
+			.on(quizRank.userId.eq(user.id))
+			.fetch();
+	}
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/repository/UserRepository.java
@@ -1,16 +1,16 @@
 package com.tdns.toks.core.domain.user.repository;
 
-import com.tdns.toks.core.domain.user.model.entity.User;
-import com.tdns.toks.core.domain.user.type.UserProvider;
-import com.tdns.toks.core.domain.user.type.UserStatus;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.tdns.toks.core.domain.user.model.entity.User;
+import com.tdns.toks.core.domain.user.type.UserProvider;
+import com.tdns.toks.core.domain.user.type.UserStatus;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
     Optional<User> findByEmail(String email);
 
     boolean existsByNickname(String Nickname);


### PR DESCRIPTION
## ✔️ PR 타입
- 기능

## 📃 개요
- 퀴즈 다건 조회 API 구현하였습니다.
- [API 스펙](https://www.notion.so/depromeet/API-b3066238124e43e6b836030ce109f0f0#2027ba289219480f974c2b23edd20dc1)

## ✏️ 변경사항
### 퀴즈 단건 조회 API
- studyId로 퀴즈를 조회
- 미제출자 필터링 로직
```
1. quiz_rank 에서 스터디의 참가자를 조회합니다.
2. quiz_reply_history 에서 스터디의 답변을 조회힙니다.
3. 미제출자를 필터링하기 위해 1에서 2를 제거합니다.
```

## 🫥 TODO
- 퀴즈 생성 API
- AuditAware 구현