### PR TITLE
#50 Flyway 빌드 실패 버그 수정

### DIFF
--- a/flyway/build.gradle
+++ b/flyway/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         String encryptorPassword = System.getenv("JASYPT_ENCRYPTOR_PASSWORD")
         set('encryptorPassword', encryptorPassword)
 
-        String buildPhase = System.getProperty("flyway.placeholders.environment", "dev")
+        String buildPhase = System.getProperty("flyway.placeholders.environment", "local")
         set('buildPhase', buildPhase)
     }
     dependencies {


### PR DESCRIPTION
## ✔️ PR 타입
- 버그
## 📃 개요
- Flyway 빌드 실패 버그 수정를 수정합니다.
  - dev 환경으로 빌드 시에 db 정보가 암호화 되어 있는데,암호화 키가 없어서 빌드가 되지 않고 있습니다.
## ✏️ 변경사항
- 초기 빌드시에 암호화가 없는 local으로 설정하여 암호화 키가 없어도 빌드가 되도록 합니다. 
## 🫥 TODO
