### PR TITLE
#70 filter 로직 단일화, exceptionHandling을 통한 no-auth 처리

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/filter/LoggingFilter.java
+++ b/api/src/main/java/com/tdns/toks/api/filter/LoggingFilter.java
@@ -1,23 +1,20 @@
 package com.tdns.toks.api.filter;
 
-import java.io.IOException;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import lombok.extern.slf4j.Slf4j;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -72,6 +69,9 @@ public class LoggingFilter extends OncePerRequestFilter {
 	}
 
 	private String contentBody(final byte[] contents) {
+		if (contents.length == 0) {
+			return "";
+		}
 		ObjectMapper mapper = new ObjectMapper();
 		String json = "";
 		try {

--- a/core/src/main/java/com/tdns/toks/core/common/filter/JwtAuthenticationFilter.java
+++ b/core/src/main/java/com/tdns/toks/core/common/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.tdns.toks.core.common.filter;
 
-import com.tdns.toks.core.common.exception.ApplicationErrorException;
 import com.tdns.toks.core.common.exception.ApplicationErrorType;
 import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
 import com.tdns.toks.core.common.security.JwtTokenProvider;
@@ -8,7 +7,6 @@ import com.tdns.toks.core.domain.user.model.dto.UserDTO;
 import com.tdns.toks.core.domain.user.model.entity.User;
 import com.tdns.toks.core.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,7 +20,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -46,11 +43,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String token = jwtTokenProvider.getAuthToken(request);
 
-        // permitUrl에 포함되지 않고 토큰이 없는 경우 에러 발생
-        if (!Arrays.stream(permitUrl).anyMatch(fl -> request.getServletPath().contains(fl)) && StringUtils.isEmpty(token)) {
-            throw new ApplicationErrorException(ApplicationErrorType.INVALID_ACCESS_TOKEN);
-        }
-
         if (token != null) {
             if (jwtTokenProvider.verifyToken(token)) {
                 String email = jwtTokenProvider.getUid(token);
@@ -70,13 +62,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 "",
                 List.of(new SimpleGrantedAuthority(user.getUserRole().getAuthority()))
         );
-    }
-
-    @Override
-    // Auth Filter 안태우는 URL 추가
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        return filterSkipUrl.stream()
-                .anyMatch(ex -> request.getServletPath().contains(ex));
     }
 }
 

--- a/core/src/main/java/com/tdns/toks/core/common/security/oauth/OAuth2SuccessHandler.java
+++ b/core/src/main/java/com/tdns/toks/core/common/security/oauth/OAuth2SuccessHandler.java
@@ -1,6 +1,5 @@
 package com.tdns.toks.core.common.security.oauth;
 
-import com.tdns.toks.core.common.security.JwtTokenProvider;
 import com.tdns.toks.core.common.type.JwtToken;
 import com.tdns.toks.core.domain.user.model.dto.UserDetailDTO;
 import lombok.RequiredArgsConstructor;
@@ -29,11 +28,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+
         var userDetailDTO = (UserDetailDTO) authentication.getPrincipal();
 
         String host = "https://tokstudy.com";
 
-        if (!request.getHeader("host").equals("https://tokstudy.com")) {
+        if (!"https://tokstudy.com".equals(request.getHeader("origin"))) {
             host = local;
         }
 

--- a/core/src/main/java/com/tdns/toks/core/config/security/AuthSecurityConfig.java
+++ b/core/src/main/java/com/tdns/toks/core/config/security/AuthSecurityConfig.java
@@ -1,9 +1,12 @@
 package com.tdns.toks.core.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tdns.toks.core.common.exception.ApplicationErrorType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -45,6 +48,8 @@ public class AuthSecurityConfig extends WebSecurityConfigurerAdapter {
     private final OAuth2FailureHandler oAuth2FailureHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
 
+    ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.httpBasic().disable()
@@ -58,6 +63,13 @@ public class AuthSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                     .antMatchers(permitUrl).permitAll()
                     .anyRequest().authenticated()
+                .and()
+                .exceptionHandling()
+                    .authenticationEntryPoint((request, response, authException) -> {
+                            response.setContentType("application/json");
+                            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                            response.getWriter().write(objectMapper.writeValueAsString(ApplicationErrorType.NO_AUTHORIZATION));
+                    })
                 .and()
                 .oauth2Login()
                     .authorizationEndpoint()


### PR DESCRIPTION
## ✔️ PR 타입

- 개선

## 📃 개요

- origin / referrer로 host 구분짓기
- 모든 인증에러는 401로 내리기
- 필터로 다시 몰아넣기
- cors 에러 해결

## ✏️ 변경사항

## 🫥 TODO
