### PR TITLE
#63 순위 관련 API 필드 추가

### DIFF
--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/dto/QuizRankDTO.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/dto/QuizRankDTO.java
@@ -7,7 +7,11 @@ import lombok.Getter;
 @Getter
 public class QuizRankDTO {
 
-	private Long quizRankId;
 	private Integer score;
+	private Integer rank;
 	private UserSimpleDTO user;
+
+	public void updateRank(Integer rank) {
+		this.rank = rank;
+	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/CustomQuizRankRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/CustomQuizRankRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.tdns.toks.core.domain.quizrank.repository;
 
 import static com.tdns.toks.core.domain.quizrank.model.entity.QQuizRank.*;
+import static com.tdns.toks.core.domain.study.model.entity.QStudyUser.*;
 import static com.tdns.toks.core.domain.user.model.entity.QUser.*;
 
 import java.util.List;
@@ -21,7 +22,6 @@ public class CustomQuizRankRepositoryImpl implements CustomQuizRankRepository {
 	public List<QuizRankDTO> retrieveByStudyId(final Long studyId) {
 		return jpaQueryFactory.select(
 				Projections.fields(QuizRankDTO.class,
-					quizRank.id.as("quizRankId"),
 					quizRank.score.as("score"),
 					Projections.fields(UserSimpleDTO.class,
 						user.id.as("userId"),
@@ -30,11 +30,14 @@ public class CustomQuizRankRepositoryImpl implements CustomQuizRankRepository {
 					).as("user")
 				)
 			)
-			.from()
-			.where(quizRank.studyId.eq(studyId)
+			.from(quizRank)
+			.where(studyUser.studyId.eq(studyId)
 				.and(user.status.eq(UserStatus.ACTIVE)))
+			.rightJoin(studyUser)
+			.on(quizRank.studyId.eq(studyUser.studyId)
+				.and(quizRank.userId.eq(studyUser.userId)))
 			.innerJoin(user)
-			.on(quizRank.userId.eq(user.id))
+			.on(studyUser.userId.eq(user.id))
 			.orderBy(quizRank.score.desc())
 			.fetch();
 	}

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/CustomQuizRankRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/CustomQuizRankRepositoryImpl.java
@@ -38,6 +38,7 @@ public class CustomQuizRankRepositoryImpl implements CustomQuizRankRepository {
 				.and(quizRank.userId.eq(studyUser.userId)))
 			.innerJoin(user)
 			.on(studyUser.userId.eq(user.id))
+			.orderBy(user.nickname.asc())
 			.orderBy(quizRank.score.desc())
 			.fetch();
 	}

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/service/QuizRankService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/service/QuizRankService.java
@@ -14,10 +14,27 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @RequiredArgsConstructor
 public class QuizRankService {
-
 	private final QuizRankRepository quizRankRepository;
 
 	public List<QuizRankDTO> getByStudyId(final Long studyId) {
-		return quizRankRepository.retrieveByStudyId(studyId);
+		var dto = quizRankRepository.retrieveByStudyId(studyId);
+		return calculateRank(dto);
+	}
+
+	private List<QuizRankDTO> calculateRank(final List<QuizRankDTO> dtos) {
+		int rank = 1;
+		int prevScore = 0;
+
+		for (QuizRankDTO dto : dtos) {
+			if (dto.getScore() == null) {
+				break;
+			}
+			if (dto.getScore() < prevScore) {
+				rank++;
+			}
+			dto.updateRank(rank);
+			prevScore = dto.getScore();
+		}
+		return dtos;
 	}
 }


### PR DESCRIPTION
## ✔️ PR 타입
- 기능
## 📃 개요
- 순위 계산해서, 등수를 포함한 필드를 추가합니다.

## ✏️ 변경사항
### 등수 필드 추가
- score를 기준으로 등수를 계산합니다.
- score가 같은 경우에는, 이름 기준으로 오름차순 정렬합니다.
- score가 없는 경우(제출한 답변이 없는 경우 / 제출한 답변은 있지만 답변 좋아요를 받지 못한 경우), rank를 null 로 반환합니다.

## 🫥 TODO
