### PR TITLE
#78 똑순위 계산 방식 반영

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizLikeApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizLikeApiService.java
@@ -6,8 +6,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.tdns.toks.api.domain.quiz.model.dto.QuizLikeApiDTO;
 import com.tdns.toks.api.domain.quiz.model.dto.QuizLikeApiDTO.QuizLikeRequest;
 import com.tdns.toks.api.domain.quiz.model.mapper.QuizLikeMapper;
-import com.tdns.toks.core.domain.quiz.service.QuizReplyHistoryService;
 import com.tdns.toks.core.domain.quiz.service.QuizLikeService;
+import com.tdns.toks.core.domain.quiz.service.QuizReplyHistoryService;
+import com.tdns.toks.core.domain.quiz.service.QuizService;
+import com.tdns.toks.core.domain.quizrank.service.QuizRankService;
 import com.tdns.toks.core.domain.user.model.dto.UserDetailDTO;
 
 import lombok.RequiredArgsConstructor;
@@ -18,11 +20,16 @@ import lombok.RequiredArgsConstructor;
 public class QuizLikeApiService {
 	private final QuizLikeService quizLikeService;
 	private final QuizReplyHistoryService quizReplyHistoryService;
+	private final QuizRankService quizRankService;
+	private final QuizService quizService;
 	private final QuizLikeMapper mapper;
 
 	public QuizLikeApiDTO.QuizLikeResponse like(final QuizLikeRequest request) {
 		var quizReplyHistory = quizReplyHistoryService.getOrThrow(request.getQuizReplyHistoryId());
 		quizLikeService.checkAlreadyLike(UserDetailDTO.get().getId(), quizReplyHistory.getQuizId());
+
+		var quiz = quizService.getOrThrow(quizReplyHistory.getQuizId());
+		quizRankService.updateScore(quizReplyHistory.getCreatedBy(), quiz.getStudyId());
 
 		return QuizLikeApiDTO.QuizLikeResponse.toResponse(quizLikeService.create(mapper.toEntity(request)));
 	}

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/model/entity/Quiz.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/model/entity/Quiz.java
@@ -76,15 +76,35 @@ public class Quiz extends BaseTimeEntity {
 		final List<String> imageUrls,
 		final Long studyId
 	) {
-		return Quiz.builder()
-			.quiz(quiz)
-			.quizType(quizType)
-			.description(description)
-			.answer(answer)
-			.startedAt(startedAt)
-			.endedAt(endedAt)
-			.imageUrls(imageUrls)
-			.studyId(studyId)
-			.build();
+		return new Quiz(
+			quiz,
+			quizType,
+			description,
+			answer,
+			startedAt,
+			endedAt,
+			imageUrls,
+			studyId
+		);
+	}
+
+	public Quiz(
+		final String quiz,
+		final QuizType quizType,
+		final String description,
+		final String answer,
+		final LocalDateTime startedAt,
+		final LocalDateTime endedAt,
+		final List<String> imageUrls,
+		final Long studyId
+	) {
+		this.quiz = quiz;
+		this.quizType = quizType;
+		this.description = description;
+		this.answer = answer;
+		this.startedAt = startedAt;
+		this.endedAt = endedAt;
+		this.imageUrls = imageUrls;
+		this.studyId = studyId;
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.tdns.toks.core.domain.quiz.model.entity.Quiz;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long>, QuizCustomRepository {
-
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/entity/QuizRank.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/entity/QuizRank.java
@@ -30,4 +30,26 @@ public class QuizRank extends BaseTimeEntity {
 
 	@Column(nullable = false, columnDefinition = "BIGINT COMMENT '스터디 id'")
 	private Long studyId;
+
+	public static QuizRank of(
+		final Integer score,
+		final Long userId,
+		final Long studyId
+	) {
+		return new QuizRank(score, userId, studyId);
+	}
+
+	public QuizRank(
+		final Integer score,
+		final Long userId,
+		final Long studyId
+	) {
+		this.score = score;
+		this.userId = userId;
+		this.studyId = studyId;
+	}
+
+	public void plusScore() {
+		this.score++;
+	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/entity/QuizRank.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/model/entity/QuizRank.java
@@ -49,7 +49,7 @@ public class QuizRank extends BaseTimeEntity {
 		this.studyId = studyId;
 	}
 
-	public void plusScore() {
-		this.score++;
+	public void plusScore(int score) {
+		this.score += score;
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/QuizRankRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/repository/QuizRankRepository.java
@@ -1,8 +1,11 @@
 package com.tdns.toks.core.domain.quizrank.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tdns.toks.core.domain.quizrank.model.entity.QuizRank;
 
 public interface QuizRankRepository extends JpaRepository<QuizRank, Long>, CustomQuizRankRepository {
+	Optional<QuizRank> findByUserIdAndStudyId(Long userId, Long StudyId);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/service/QuizRankService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/service/QuizRankService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tdns.toks.core.domain.quizrank.model.dto.QuizRankDTO;
+import com.tdns.toks.core.domain.quizrank.model.entity.QuizRank;
 import com.tdns.toks.core.domain.quizrank.repository.QuizRankRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,19 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @RequiredArgsConstructor
 public class QuizRankService {
-
 	private final QuizRankRepository quizRankRepository;
 
 	public List<QuizRankDTO> getByStudyId(final Long studyId) {
 		return quizRankRepository.retrieveByStudyId(studyId);
+	}
+
+	public void updateScore(final Long userId, final Long studyId) {
+		var quizRank =  quizRankRepository.findByUserIdAndStudyId(userId, studyId)
+			.orElseGet(() -> save(userId, studyId));
+		quizRank.plusScore();
+	}
+
+	public QuizRank save(final Long userId, final Long studyId) {
+		return quizRankRepository.save(QuizRank.of(0, userId, studyId));
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quizrank/service/QuizRankService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quizrank/service/QuizRankService.java
@@ -24,7 +24,7 @@ public class QuizRankService {
 	public void updateScore(final Long userId, final Long studyId) {
 		var quizRank =  quizRankRepository.findByUserIdAndStudyId(userId, studyId)
 			.orElseGet(() -> save(userId, studyId));
-		quizRank.plusScore();
+		quizRank.plusScore(1);
 	}
 
 	public QuizRank save(final Long userId, final Long studyId) {


### PR DESCRIPTION
## ✔️ PR 타입
- 기능
## 📃 개요
- 득표수를 순위에 그대로 반영하는 똑순위 계산 방식을 반영합니다.

## ✏️ 변경사항
### 똑순위 계산 방식 반영
- userId, studyId 로 quiz_rank 를 찾습니다.
- 없는 경우 생성하여 score를 증가시킵니다.
- 이미 존재하는 경우, score를 증가시킵니다.
## 🫥 TODO
