### PR TITLE
#85 입장 시 스터디 정보 조회 api 

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
@@ -1,23 +1,8 @@
 package com.tdns.toks.api.domain.study.controller;
 
 import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.*;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudiesInfoResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyApiResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyCreateRequest;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyFormResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.TagResponse;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.tdns.toks.api.domain.study.service.StudyApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
-import com.tdns.toks.core.domain.study.model.dto.TagDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -29,8 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -148,6 +131,24 @@ public class StudyController {
             @PathVariable final Long studyId
     ) {
         var response = studyApiService.getStudyDetails(studyId);
+        return ResponseDto.ok(response);
+    }
+
+    @GetMapping("/{studyId}/enter")
+    @Operation(
+            method = "GET",
+            summary = "참여 스터디 정보 조회"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = StudyEntranceDetailsResponse.class))}),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
+    public ResponseEntity<StudyEntranceDetailsResponse> getStudyEntranceDetails(
+            @PathVariable final Long studyId
+    ) {
+        var response = studyApiService.getStudyEntranceDetails(studyId);
         return ResponseDto.ok(response);
     }
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
@@ -17,7 +17,6 @@ import org.springframework.format.annotation.DateTimeFormat;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -181,6 +180,46 @@ public class StudyApiDTO {
                     .startedAt(study.getStartedAt())
                     .endedAt(study.getEndedAt())
                     .users(users)
+                    .tags(tags)
+                    .build();
+        }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Builder
+    @Schema(name = "StudyEntranceDetailsResponse", description = "참여 스터디 정보 반환 모델")
+    public static class StudyEntranceDetailsResponse{
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "id", description = "스터디 id")
+        private Long id;
+
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "name", description = "스터디 이름")
+        private String name;
+
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "description", description = "스터디 설명")
+        private String description;
+
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "startedAt", description = "시작 일자 ex: 2000-10-31T01:30:00.000-05:00")
+        private LocalDateTime startedAt;
+
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "endedAt", description = "종료 일자 ex: 2000-10-31T01:30:00.000-05:00")
+        private LocalDateTime endedAt;
+
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "capacity", description = "SMALL || MEDIUM || LARGE")
+        private StudyCapacity capacity;
+
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "tags", description = "스터디 태그 목록")
+        private List<TagDTO> tags;
+
+        public static StudyEntranceDetailsResponse toResponse(Study study, List<TagDTO> tags) {
+            return StudyEntranceDetailsResponse.builder()
+                    .id(study.getId())
+                    .name(study.getName())
+                    .description(study.getDescription())
+                    .capacity(study.getCapacity())
+                    .startedAt(study.getStartedAt())
+                    .endedAt(study.getEndedAt())
                     .tags(tags)
                     .build();
         }

--- a/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
@@ -87,7 +87,7 @@ public class StudyApiDTO {
 
         private UserDTO user;
 
-        private List<TagDTO> tagList;
+        private List<TagDTO> tags;
 
         public static StudyApiResponse toResponse(Study study, UserDTO userDTO, List<Tag> tagList) {
             StudyApiResponse response = new StudyApiResponse();
@@ -99,7 +99,7 @@ public class StudyApiDTO {
             response.capacity = study.getCapacity();
             response.inviteUrl = UrlConvertUtil.convertToInviteUrl(study.getId());
             response.user = userDTO;
-            response.tagList = tagList.stream().map(tag -> TagDTO.of(tag)).collect(Collectors.toList());
+            response.tags = tagList.stream().map(tag -> TagDTO.of(tag)).collect(Collectors.toList());
             return response;
         }
     }

--- a/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
@@ -24,7 +24,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -132,5 +131,11 @@ public class StudyApiService {
         var tags = tagService.getStudyTagsDTO(studyId);
         var study = studyService.getStudy(studyId);
         return StudyDetailsResponse.toResponse(study, users, tags);
+    }
+
+    public StudyEntranceDetailsResponse getStudyEntranceDetails(Long studyId) {
+        var tags = tagService.getStudyTagsDTO(studyId);
+        var study = studyService.getStudy(studyId);
+        return StudyEntranceDetailsResponse.toResponse(study, tags);
     }
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -68,7 +68,7 @@ cloud:
 
 # security
 security:
-  permit-url: /api-docs/**,/configuration/**,/swagger-ui/**,/webjars/**,/actuator/health,/swagger/**,/swagger/index.html,/login/**,/api/v1/user/renew
+  permit-url: /api-docs/**,/configuration/**,/swagger-ui/**,/webjars/**,/actuator/health,/swagger/**,/swagger/index.html,/login/**,/api/v1/user/renew,/api/v1/studies/*/enter
   filter-skip: /actuator/health,/api-docs,/configuration,/swagger,/swagger-ui,/webjars,/swagger/**,/api/v1/user/renew,/login
 
 # swagger


### PR DESCRIPTION
## ✔️ PR 타입

- 기능

## 📃 개요

- 입장 시 토큰 없이도 해당 스터디 정보 조회 가능하도록 api 추가

## ✏️ 변경사항

- controller ("/api/v1/studies/{studyid}/enter") 추가
- 스터디 생성 부분 변수명 변경 (tagList -> tags)

## 🫥 TODO
