### PR TITLE
:recycle: Referer가 존재하고 localhost일 때만 localhost로 리다이렉트

### DIFF
--- a/core/src/main/java/com/tdns/toks/core/common/security/oauth/OAuth2SuccessHandler.java
+++ b/core/src/main/java/com/tdns/toks/core/common/security/oauth/OAuth2SuccessHandler.java
@@ -34,7 +34,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String host = "https://tokstudy.com";
 
         String referer = request.getHeader("Referer");
-        if (referer == null || !referer.contains("https://tokstudy.com")) {
+        if (referer != null && referer.contains("localhost")) {
             host = local;
         }
 


### PR DESCRIPTION
## ✔️ PR 타입

- 수정

## 📃 개요

- 중간중간 모종의 이유로 localhost로 리다이렉트 튀는 경우 처리😅

## ✏️ 변경사항

- 모든 경우 tokstudy.com으로 리다이렉트
- referer가 존재하고 referer에 localhost가 담겨있으면 localhost로 리다이렉트 하도록 수정

## 🫥 TODO
