### PR TITLE
#98 스터디 정보 조회 시, 최신 퀴즈 회차 반환

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
@@ -183,6 +183,9 @@ public class StudyApiDTO {
         @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "tags", description = "스터디 태그 목록")
         private List<TagDTO> tags;
 
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "latestQuizRound", description = "최신 스터디 회차")
+        private Integer latestQuizRound;
+
         public static StudyDetailsResponse toResponse(Study study, List<UserSimpleDTO> users, List<TagDTO> tags) {
             return StudyDetailsResponse.builder()
                     .id(study.getId())
@@ -192,6 +195,7 @@ public class StudyApiDTO {
                     .endedAt(study.getEndedAt())
                     .users(users)
                     .tags(tags)
+                    .latestQuizRound(study.getLatestQuizRound())
                     .build();
         }
     }

--- a/api/src/main/java/com/tdns/toks/api/domain/study/model/mapper/StudyApiMapper.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/model/mapper/StudyApiMapper.java
@@ -7,7 +7,6 @@ import com.tdns.toks.core.domain.study.model.entity.Tag;
 import com.tdns.toks.core.domain.study.type.StudyStatus;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +23,7 @@ public class StudyApiMapper {
                 .capacity(studyCreateRequest.getCapacity())
                 .studyUserCount(0)
                 .leaderId(userId)
+                .latestQuizRound(0)
                 .build();
     }
 

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
@@ -8,6 +8,7 @@ import com.tdns.toks.core.domain.quiz.repository.QuizReplyHistoryRepository;
 import com.tdns.toks.core.domain.quiz.repository.QuizRepository;
 import com.tdns.toks.core.domain.quiz.type.QuizStatusType;
 import com.tdns.toks.core.domain.quiz.type.StudyLatestQuizStatus;
+import com.tdns.toks.core.domain.study.repository.StudyRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ import java.util.List;
 @Transactional
 @RequiredArgsConstructor
 public class QuizService {
+    private final StudyRepository studyRepository;
     private final QuizRepository quizRepository;
     private final QuizReplyHistoryRepository quizReplyHistoryRepository;
 
@@ -71,6 +73,7 @@ public class QuizService {
     }
 
 	public Quiz save(final Quiz quiz) {
+        studyRepository.getById(quiz.getStudyId()).updateLatestQuizRound();
 		return quizRepository.save(quiz);
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/study/model/entity/Study.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/model/entity/Study.java
@@ -46,7 +46,14 @@ public class Study extends BaseTimeEntity implements Serializable {
     @Column(columnDefinition = "BIGINT COMMENT '스터디장 user_id'")
     private Long leaderId;
 
+    @Column(columnDefinition = "TINYINT COMMENT '최신 스터디 회차'")
+    private Integer latestQuizRound;
+
     public void updateStudyUserCount(int count) {
         this.studyUserCount += count;
+    }
+
+    public void updateLatestQuizRound() {
+        this.latestQuizRound += 1;
     }
 }

--- a/core/src/test/java/com/tdns/toks/core/domain/quiz/QuizServiceTest.java
+++ b/core/src/test/java/com/tdns/toks/core/domain/quiz/QuizServiceTest.java
@@ -1,23 +1,24 @@
 package com.tdns.toks.core.domain.quiz;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
-
-import java.util.Optional;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
 import com.tdns.toks.core.domain.quiz.repository.QuizReplyHistoryRepository;
 import com.tdns.toks.core.domain.quiz.repository.QuizRepository;
 import com.tdns.toks.core.domain.quiz.service.QuizService;
+import com.tdns.toks.core.domain.study.repository.StudyRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
 public class QuizServiceTest {
 	private final QuizRepository quizRepository = mock(QuizRepository.class);
 	private final QuizReplyHistoryRepository quizReplyHistoryRepository  = mock(QuizReplyHistoryRepository.class);
+	private final StudyRepository studyRepository = mock(StudyRepository.class);
 
-	private final QuizService sut = new QuizService(quizRepository, quizReplyHistoryRepository);
+	private final QuizService sut = new QuizService(studyRepository, quizRepository, quizReplyHistoryRepository);
 
 	@Test
 	@DisplayName("퀴즈가 없으면 SilentApplicationErrorException 던진다")

--- a/flyway/src/main/resources/db/migration/schema/V1.17__alterTableStudy.sql
+++ b/flyway/src/main/resources/db/migration/schema/V1.17__alterTableStudy.sql
@@ -1,0 +1,5 @@
+--
+-- Table structure for table `study`
+--
+
+ALTER TABLE `study` ADD COLUMN `latest_quiz_round` tinyint not null default 0;


### PR DESCRIPTION
## ✔️ PR 타입

- 개선

## 📃 개요

- 스터디 Entity에 최신 퀴즈 회차 정보 추가

## ✏️ 변경사항

- Study 테이블 latest_quiz_round 칼럼 추가 
- Study 엔티티 latestQuizRound 추가
- 퀴즈 생성시 최신 라운드 +1 update
- 스터디 정보 조회시 latestQuizRound 정보 추가
- Flyway 반영

## 🫥 TODO
