### PR TITLE
#103 스터디 진행도 표기

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/model/dto/StudyApiDTO.java
@@ -9,6 +9,7 @@ import com.tdns.toks.core.domain.study.model.dto.TagDTO;
 import com.tdns.toks.core.domain.study.model.entity.Study;
 import com.tdns.toks.core.domain.study.model.entity.Tag;
 import com.tdns.toks.core.domain.study.type.StudyCapacity;
+import com.tdns.toks.core.domain.study.type.StudyProgress;
 import com.tdns.toks.core.domain.user.model.dto.UserDTO;
 import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -186,6 +187,9 @@ public class StudyApiDTO {
         @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "latestQuizRound", description = "최신 스터디 회차")
         private Integer latestQuizRound;
 
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "progress", description = "스터디 진행도")
+        private StudyProgress progress;
+
         public static StudyDetailsResponse toResponse(Study study, List<UserSimpleDTO> users, List<TagDTO> tags) {
             return StudyDetailsResponse.builder()
                     .id(study.getId())
@@ -196,6 +200,7 @@ public class StudyApiDTO {
                     .users(users)
                     .tags(tags)
                     .latestQuizRound(study.getLatestQuizRound())
+                    .progress(StudyProgress.getProgress(study.getStartedAt(), study.getEndedAt(), LocalDateTime.now()))
                     .build();
         }
     }

--- a/core/src/main/java/com/tdns/toks/core/domain/study/type/StudyProgress.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/type/StudyProgress.java
@@ -1,0 +1,34 @@
+package com.tdns.toks.core.domain.study.type;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+public enum StudyProgress {
+    STEP0(0), STEP1(16), STEP2(33), STEP3(50), STEP4(66), STEP5(83);
+
+    public final int value;
+
+    StudyProgress(int value) {
+        this.value = value;
+    }
+
+    private int getValue() {
+        return this.value;
+    }
+
+    public static StudyProgress getProgress(LocalDateTime startedAt, LocalDateTime endedAt, LocalDateTime now) {
+        long total = Duration.between(startedAt, endedAt).getSeconds();
+        long onGoing = Duration.between(startedAt, now).getSeconds();
+        if (onGoing < 0) {
+            return STEP0;
+        }
+        int progress = (int)((onGoing * 100.0) / total + 0.5);
+        StudyProgress[] studyProgresses = StudyProgress.values();
+        for (int i = 0; i < studyProgresses.length-1; i++) {
+            if (studyProgresses[i].getValue() <= progress && progress < studyProgresses[i + 1].getValue()) {
+                return studyProgresses[i];
+            }
+        }
+        return STEP5;
+    }
+}


### PR DESCRIPTION
## ✔️ PR 타입

- 개선

## 📃 개요

- 스터디 단건 조회 시, 해당 스터디의 진행도를 구간에 따라 구분하여 값 전달 
- “STEP1", “STEP2”, “STEP3”, “STEP4”, “STEP5", "STEP6" 각각 (0, 16, 33, 50, 66, 83) 기준으로 나뉨

## ✏️ 변경사항

- Enum 추가  (계산 로직 포함)
- 반환값 "progress" 추가

## 🫥 TODO
