### PR TITLE
퀴즈 생성 및 답변 조회 이슈 해결

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/service/QuizApiService.java
@@ -61,6 +61,8 @@ public class QuizApiService {
 	public QuizCreateResponse create(
 		final QuizRequest request
 	) {
+		quizService.checkDuplicatedRound(request.getRound());
+
 		var urls = s3UploadService.uploadFiles(
 			Optional.ofNullable(request.getImageFiles()).orElse(Collections.emptyList()),
 			UserDetailDTO.get().getId().toString()

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/QuizReplyHistoryDto.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/model/dto/QuizReplyHistoryDto.java
@@ -9,6 +9,6 @@ public class QuizReplyHistoryDto {
 
 	private Long quizReplyHistoryId;
 	private String answer;
-	private Long likeNumber;
+	private Long likeCount;
 	private UserSimpleDTO creator;
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizReplyHistoryCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizReplyHistoryCustomRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Sort;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tdns.toks.core.domain.quiz.model.dto.QuizReplyHistoryDto;
@@ -32,7 +33,10 @@ public class QuizReplyHistoryCustomRepositoryImpl implements QuizReplyHistoryCus
 				Projections.fields(QuizReplyHistoryDto.class,
 					quizReplyHistory.id.as("quizReplyHistoryId"),
 					quizReplyHistory.answer.as("answer"),
-					quizReplyHistory.count().as("likeNumber"),
+					new CaseBuilder()
+						.when(quizLike.id.max().isNull())
+						.then(0L)
+						.otherwise(quizReplyHistory.count()).as("likeCount"),
 					Projections.fields(UserSimpleDTO.class,
 						user.id.as("userId"),
 						user.nickname.as("nickname"),
@@ -45,7 +49,7 @@ public class QuizReplyHistoryCustomRepositoryImpl implements QuizReplyHistoryCus
 				.and(user.status.eq(UserStatus.ACTIVE)))
 			.innerJoin(user)
 			.on(quizReplyHistory.createdBy.eq(user.id))
-			.innerJoin(quizLike) // FIXME: 투표한 사람이 없는 경우, join 불가
+			.leftJoin(quizLike)
 			.on(quizReplyHistory.id.eq(quizLike.quizReplyHistoryId))
 			.orderBy(getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
 			.groupBy(quizReplyHistory.id)
@@ -58,8 +62,8 @@ public class QuizReplyHistoryCustomRepositoryImpl implements QuizReplyHistoryCus
 			Order direction = order.isAscending() ? Order.ASC : Order.DESC;
 			String prop = order.getProperty();
 
-			if (prop.equals("likeNumber")) {
-				orderSpecifiers.add(getNumberLikeOrderSpecifier(direction));
+			if (prop.equals("likeCount")) {
+				orderSpecifiers.addAll(getLikeCountOrderSpecifier(direction));
 				return;
 			}
 
@@ -69,10 +73,15 @@ public class QuizReplyHistoryCustomRepositoryImpl implements QuizReplyHistoryCus
 		return orderSpecifiers;
 	}
 
-	private OrderSpecifier getNumberLikeOrderSpecifier(Order order) {
+	private List<OrderSpecifier> getLikeCountOrderSpecifier(Order order) {
+		List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
 		if (order == Order.ASC) {
-			return quizReplyHistory.count().asc();
+			orderSpecifiers.add(quizReplyHistory.count().asc());
+			orderSpecifiers.add(quizLike.id.max().asc());
+		} else {
+			orderSpecifiers.add(quizReplyHistory.count().desc());
+			orderSpecifiers.add(quizLike.id.max().desc());
 		}
-		return quizReplyHistory.count().desc();
+		return orderSpecifiers;
 	}
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizRepository.java
@@ -1,11 +1,13 @@
 package com.tdns.toks.core.domain.quiz.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tdns.toks.core.domain.quiz.model.entity.Quiz;
 
-import java.util.Optional;
-
 public interface QuizRepository extends JpaRepository<Quiz, Long>, QuizCustomRepository {
     Optional<Quiz> findFirstByStudyIdOrderByCreatedAtDesc(Long studyId);
+
+    Boolean existsByRound(Integer round);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizReplyHistoryService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizReplyHistoryService.java
@@ -36,8 +36,7 @@ public class QuizReplyHistoryService {
 	}
 
 	public List<QuizReplyHistoryDto> getAllByQuizId(final Long quizId, final Pageable pageable) {
-		var test =  quizReplyHistoryRepository.retrieveByQuizId(quizId, pageable);
-		return test;
+		return  quizReplyHistoryRepository.retrieveByQuizId(quizId, pageable);
 	}
 
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/service/QuizService.java
@@ -78,4 +78,10 @@ public class QuizService {
         studyRepository.getById(quiz.getStudyId()).updateLatestQuizRound();
 		return quizRepository.save(quiz);
 	}
+
+    public void checkDuplicatedRound(final Integer round) {
+        if (quizRepository.existsByRound(round)) {
+            throw new SilentApplicationErrorException(ApplicationErrorType.INVALID_REQUEST);
+        }
+    }
 }


### PR DESCRIPTION
## ✔️ PR 타입
- 버그
- 기능
## 📃 개요
- 퀴즈 생성 시에 중복된 회차인지 체크하는 메서드 생성
- 답변 조회 시, 투표를 못 받은 답변은 조회 못하는 이슈 해결
- likeNumber -> likeCount 로 필드 변경
## ✏️ 변경사항
### 중복된 회차인지 체크하는 메서드 생성
  fyi; [체크하는 로직 필요성 관련 스레드](https://5gaeanmal.slack.com/archives/C044R1B6526/p1672739556936779)

### 답변 조회 시, 투표를 못 받은 답변은 조회 못하는 이슈 해결
fyi; [관련 이슈 보고 스레드](https://5gaeanmal.slack.com/archives/C048PJ8V47P/p1672815230677219)
- quiz_like table 을 inner join 에서 left join 으로 변경
- caseBuilder를 사용하여, quiz_like_id 가 null 인 경우(투표를 하나도 받지 못한 경우) 좋아요 받은 개수를 0 으로 분기처리

## 🫥 TODO
