### PR TITLE
Hotfix/quiz reply history sort

### DIFF
--- a/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizReplyHistoryCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/quiz/repository/QuizReplyHistoryCustomRepositoryImpl.java
@@ -56,8 +56,8 @@ public class QuizReplyHistoryCustomRepositoryImpl implements QuizReplyHistoryCus
 			.on(quizReplyHistory.createdBy.eq(user.id))
 			.leftJoin(quizLike)
 			.on(quizReplyHistory.id.eq(quizLike.quizReplyHistoryId))
-			.orderBy(getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
 			.groupBy(quizReplyHistory.id)
+			.orderBy(getOrderSpecifier(pageable.getSort()).toArray(OrderSpecifier[]::new))
 			.fetch();
 	}
 


### PR DESCRIPTION
## ✔️ PR 타입
- 버그
## 📃 개요
- quiz_like.id.max()로 정렬 후에 생성날짜로 정렬이 안 되는 이슈
## ✏️ 변경사항
- alias 정렬(likeCount)로 변경
## 🫥 TODO
