### PR TITLE
#117 이미지 다중 저장 지원

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/image/controller/ImageController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/image/controller/ImageController.java
@@ -1,6 +1,7 @@
 package com.tdns.toks.api.domain.image.controller;
 
 import com.tdns.toks.api.domain.image.model.dto.ImageApiDTO.ImageUploadResponse;
+import com.tdns.toks.api.domain.image.model.dto.ImageApiDTO.ImageBulkUploadResponse;
 import com.tdns.toks.api.domain.image.service.ImageApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,6 +28,7 @@ import java.util.List;
 @RequestMapping(path = "/api/v1/images")
 @RequiredArgsConstructor
 public class ImageController {
+
     private final ImageApiService imageApiService;
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -41,10 +43,29 @@ public class ImageController {
             @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
     public ResponseEntity<ImageUploadResponse> uploadImage(
+            @RequestPart(name = "image", required = true) MultipartFile image
+    ) {
+        var response = imageApiService.uploadSingleImage(image);
+        return ResponseDto.created(response);
+    }
+
+
+    @PostMapping(value = "/bulk-load", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(
+            method = "POST",
+            summary = "이미지 최대 10개 생성"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ImageBulkUploadResponse.class))}),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
+    public ResponseEntity<ImageBulkUploadResponse> bulkUploadImages(
             @RequestPart(name = "extra") String extraInfo,
             @RequestPart(name = "image", required = true) List<MultipartFile> images
     ) {
-        var response = imageApiService.uploadImage(images, extraInfo);
+        var response = imageApiService.uploadImages(images, extraInfo);
         return ResponseDto.created(response);
     }
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/image/controller/ImageController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/image/controller/ImageController.java
@@ -1,6 +1,5 @@
 package com.tdns.toks.api.domain.image.controller;
 
-import com.tdns.toks.api.domain.image.model.dto.ImageApiDTO;
 import com.tdns.toks.api.domain.image.model.dto.ImageApiDTO.ImageUploadResponse;
 import com.tdns.toks.api.domain.image.service.ImageApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
@@ -20,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @Tag(name = "ImageConroller-V1", description = "IMAGE API")
 @RestController
@@ -34,15 +35,16 @@ public class ImageController {
             summary = "이미지 생성"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ImageApiDTO.ImageUploadResponse.class))}),
+            @ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = ImageUploadResponse.class))}),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
             @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
             @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
     public ResponseEntity<ImageUploadResponse> uploadImage(
-            @RequestPart(name = "image", required = true) MultipartFile image
+            @RequestPart(name = "extra") String extraInfo,
+            @RequestPart(name = "image", required = true) List<MultipartFile> images
     ) {
-        var response = imageApiService.uploadImage(image);
+        var response = imageApiService.uploadImage(images, extraInfo);
         return ResponseDto.created(response);
     }
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/image/model/dto/ImageApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/image/model/dto/ImageApiDTO.java
@@ -5,21 +5,9 @@ import com.tdns.toks.core.domain.image.model.entity.Image;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
-import javax.validation.constraints.NotEmpty;
 import java.util.List;
 
 public class ImageApiDTO {
-    @Builder
-    @Getter
-    @Setter
-    @AllArgsConstructor
-    @NoArgsConstructor
-    @Schema(name = "ImageUploadRequest", description = "이미지 업로드 요청 모델")
-    public static class ImageUploadRequest {
-        @NotEmpty(message = "업로드 info")
-        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "uploadInfo", description = "이미지 업로드 정보 (퀴즈 생성시 이미지 [QuizID])")
-        private String uploadInfo;
-    }
 
     @AllArgsConstructor
     @NoArgsConstructor
@@ -32,10 +20,31 @@ public class ImageApiDTO {
         private Long id;
 
         @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "imageUrl", description = "image s3 URL")
-        private List<String> imageUrl;
+        private String imageUrl;
 
         public static ImageUploadResponse toResponse(Image image) {
             return ImageUploadResponse.builder()
+                    .id(image.getId())
+                    .imageUrl(image.getImageUrl())
+                    .build();
+        }
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Getter
+    @Setter
+    @Builder
+    @Schema(name = "ImageUploadResponse", description = "이미지 업로드 응답 모델")
+    public static class ImageBulkUploadResponse {
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "id", description = "image id")
+        private Long id;
+
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "imageUrl", description = "image s3 URL")
+        private List<String> imageUrl;
+
+        public static ImageBulkUploadResponse toResponse(Image image) {
+            return ImageBulkUploadResponse.builder()
                     .id(image.getId())
                     .imageUrl(ArrayConvertUtil.convertToList(image.getImageUrl()))
                     .build();

--- a/api/src/main/java/com/tdns/toks/api/domain/image/model/dto/ImageApiDTO.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/image/model/dto/ImageApiDTO.java
@@ -1,11 +1,12 @@
 package com.tdns.toks.api.domain.image.model.dto;
 
+import com.tdns.toks.core.common.utils.ArrayConvertUtil;
 import com.tdns.toks.core.domain.image.model.entity.Image;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotEmpty;
+import java.util.List;
 
 public class ImageApiDTO {
     @Builder
@@ -15,9 +16,9 @@ public class ImageApiDTO {
     @NoArgsConstructor
     @Schema(name = "ImageUploadRequest", description = "이미지 업로드 요청 모델")
     public static class ImageUploadRequest {
-        @NotEmpty(message = "이미지 리소스 필수")
-        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "imageFile", description = "이미지 파일")
-        private MultipartFile imageFile;
+        @NotEmpty(message = "업로드 info")
+        @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "uploadInfo", description = "이미지 업로드 정보 (퀴즈 생성시 이미지 [QuizID])")
+        private String uploadInfo;
     }
 
     @AllArgsConstructor
@@ -31,12 +32,12 @@ public class ImageApiDTO {
         private Long id;
 
         @Schema(accessMode = Schema.AccessMode.READ_WRITE, required = true, name = "imageUrl", description = "image s3 URL")
-        private String imageUrl;
+        private List<String> imageUrl;
 
         public static ImageUploadResponse toResponse(Image image) {
             return ImageUploadResponse.builder()
                     .id(image.getId())
-                    .imageUrl(image.getImageUrl())
+                    .imageUrl(ArrayConvertUtil.convertToList(image.getImageUrl()))
                     .build();
         }
     }

--- a/api/src/main/java/com/tdns/toks/api/domain/image/service/ImageApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/image/service/ImageApiService.java
@@ -1,31 +1,53 @@
 package com.tdns.toks.api.domain.image.service;
 
 import com.tdns.toks.api.domain.image.model.dto.ImageApiDTO.ImageUploadResponse;
+import com.tdns.toks.core.common.exception.ApplicationErrorType;
+import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
 import com.tdns.toks.core.common.service.S3UploadService;
 import com.tdns.toks.core.domain.image.service.ImageService;
 import com.tdns.toks.core.domain.user.model.dto.UserDetailDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class ImageApiService {
+
+    @Value("${config.image-limit}")
+    private int imageLimit;
+
     private final S3UploadService s3UploadService;
 
     private final ImageService imageService;
 
-    public ImageUploadResponse uploadImage(MultipartFile image) {
+    public ImageUploadResponse uploadImage(List<MultipartFile> images, String extraInfo) {
         var uid = UserDetailDTO.get().getId();
-        var imageUrl = s3UploadService.uploadSingleFile(image, uid.toString());
 
+        if(extraInfo == null) extraInfo = "extra";
+        validateMultipartFile(images);
+
+        var imageUrl = s3UploadService.uploadFiles(images, uid.toString());
         log.info("uploadImage / uid : {} / imageUrl {}", uid, imageUrl);
-
-        var imageUploadLog = imageService.saveImage(imageUrl, uid);
+        var imageUploadLog = imageService.saveImage(imageUrl, uid, extraInfo);
         return ImageUploadResponse.toResponse(imageUploadLog);
+    }
+
+    // 첨부된 파일이 없을 때, 10장 초과일 때 Exception
+    private void validateMultipartFile(List<MultipartFile> images) {
+        if (images.size() == 1 && Objects.equals(images.get(0).getOriginalFilename(), "")) {
+            throw new SilentApplicationErrorException(ApplicationErrorType.NO_IMAGE);
+        }
+        if (images.size() > imageLimit) {
+            throw new SilentApplicationErrorException(ApplicationErrorType.EXCEEDED_IMAGE_UPLOAD_LIMIT);
+        }
     }
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/image/service/ImageApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/image/service/ImageApiService.java
@@ -36,7 +36,7 @@ public class ImageApiService {
         validateMultipartFile(images);
 
         var imageUrl = s3UploadService.uploadFiles(images, uid.toString());
-        log.info("uploadImage / uid : {} / imageUrl {}", uid, imageUrl);
+        log.info("[Image Upload] userId : {} || imageUrls {}", uid, imageUrl);
         var imageUploadLog = imageService.saveImage(imageUrl, uid, extraInfo);
         return ImageUploadResponse.toResponse(imageUploadLog);
     }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -91,3 +91,7 @@ springdoc:
 monitor:
   slack:
     cruiser: ENC(TIydYqpYJ4LIrazfFdSk0FLwfHeZ8KVgTtwtMtDT5NzlYtSxMvbn3OETKAcZCkN9Q658p5wa0IMEePSKyvAd1EA1UEBnG9aXYMGhsqg3ex4m0/Wgr8X0wIG9GY8MrBZ/T29dH+tGZIMsxX04soR30F3tRlWSnfcFdbvPkiBjRkc=)
+
+# etc
+config:
+  image-limit: 10

--- a/core/src/main/java/com/tdns/toks/core/common/exception/ApplicationErrorType.java
+++ b/core/src/main/java/com/tdns/toks/core/common/exception/ApplicationErrorType.java
@@ -24,6 +24,9 @@ public enum ApplicationErrorType {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, -20027, "error.invalid.access.token"),
     INVALID_LOGIN_INFO(HttpStatus.BAD_REQUEST, -20007, "try.again"/*Invalid Login Info*/),
     TO_JSON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, -40015, "try.again"),
+    CONVERT_STRING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 10100, "String 변환 오류"),
+    CONVERT_ARRAY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 10101, "List 변환 오류"),
+    NO_IMAGE(HttpStatus.BAD_REQUEST, 10102, "전달된 이미지 없음"),
 
     /**
      * Auth or User Error Type
@@ -49,6 +52,7 @@ public enum ApplicationErrorType {
     ALREADY_EXISTS_QUIZ_ROUND(HttpStatus.BAD_REQUEST, -20020, "퀴즈 라운드가 이미 존재합니다."),
     NOT_FOUND_QUIZ_ERROR(HttpStatus.NOT_FOUND, -20021, "해당 퀴즈가 존재하지 않습니다."),
     STILL_OPEN_LATEST_QUIZ(HttpStatus.CONFLICT, -20022, "마지막 퀴즈가 끝나지 않았습니다"),
+    EXCEEDED_IMAGE_UPLOAD_LIMIT(HttpStatus.BAD_REQUEST, 30007, "사진 등록 갯수를 초과했습니다."),
 
 
     /**

--- a/core/src/main/java/com/tdns/toks/core/common/utils/ArrayConvertUtil.java
+++ b/core/src/main/java/com/tdns/toks/core/common/utils/ArrayConvertUtil.java
@@ -1,0 +1,28 @@
+package com.tdns.toks.core.common.utils;
+
+import com.tdns.toks.core.common.exception.ApplicationErrorType;
+import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArrayConvertUtil {
+
+    //","로 구분되어있는 String을 List로 변환합니다.
+    public static List<String> convertToList(String s) {
+        try {
+            String[] split = s.split(",");
+            return new ArrayList<>(List.of(split));
+        } catch (Exception e) {
+            throw new SilentApplicationErrorException(ApplicationErrorType.CONVERT_STRING_ERROR);
+        }
+    }
+
+    public static String convertToString(List<String> arr) {
+        try {
+            return String.join(",", arr);
+        } catch (Exception e) {
+            throw new SilentApplicationErrorException(ApplicationErrorType.CONVERT_ARRAY_ERROR);
+        }
+    }
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/image/model/entity/Image.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/image/model/entity/Image.java
@@ -26,7 +26,7 @@ public class Image extends BaseTimeEntity implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(columnDefinition = "VARCHAR(512) COMMENT '퀴즈 url'")
+    @Column(columnDefinition = "VARCHAR(2047) COMMENT '이미지 URL'")
     private String imageUrl;
 
     // TODO : 생성하는 인원에 대한 정보가 없으면?
@@ -34,6 +34,6 @@ public class Image extends BaseTimeEntity implements Serializable {
     @Column(columnDefinition = "BIGINT COMMENT '생성 user_id'")
     private Long createdBy;
 
-    // extra field가 필요할듯
-    // private String extra;
+    @Column(columnDefinition = "VARCHAR(255) COMMENT '이미지 저장 정보'")
+    private String extra;
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/image/repository/ImageRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/image/repository/ImageRepository.java
@@ -2,6 +2,8 @@ package com.tdns.toks.core.domain.image.repository;
 
 import com.tdns.toks.core.domain.image.model.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/image/service/ImageService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/image/service/ImageService.java
@@ -1,10 +1,13 @@
 package com.tdns.toks.core.domain.image.service;
 
+import com.tdns.toks.core.common.utils.ArrayConvertUtil;
 import com.tdns.toks.core.domain.image.model.entity.Image;
 import com.tdns.toks.core.domain.image.repository.ImageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional
@@ -12,12 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class ImageService {
     private final ImageRepository imageRepository;
 
-    public Image saveImage(String imageUrl, Long userId) {
+    public Image saveImage(List<String> imageUrl, Long userId, String extraInfo) {
         var image = Image.builder()
-                .imageUrl(imageUrl)
+                .imageUrl(ArrayConvertUtil.convertToString(imageUrl))
                 .createdBy(userId)
+                .extra(extraInfo)
                 .build();
-
         return imageRepository.save(image);
     }
 }

--- a/flyway/src/main/resources/db/migration/schema/V1.21__alterTableImage.sql
+++ b/flyway/src/main/resources/db/migration/schema/V1.21__alterTableImage.sql
@@ -1,0 +1,6 @@
+--
+-- Table structure for table `image`
+--
+
+ALTER TABLE `image` MODIFY column `image_url` VARCHAR(2047);
+ALTER TABLE `image` ADD COLUMN `extra` VARCHAR(255);


### PR DESCRIPTION
## ✔️ PR 타입

- 기능 개선

## 📃 개요

- 이미지를 하나 혹은 여러개 저장을 지원합니다. (1~ 10개 제한)
    - 이미지가 없는 경우, 초과하는 경우 각각의 Exception 작성

## ✏️ 변경사항

- 요청 시 이미지 저장 의도를 저장하는 extraInfo를 받도록 수정

```java
@RequestPart(name = "extra") String extraInfo,
@RequestPart(name = "image", required = true) List<MultipartFile> images
```

- image 테이블 및 sql Script 수정 

## 🫥 TODO
