### PR TITLE
#133 스터디 떠나기 로직 추가

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
@@ -3,6 +3,7 @@ package com.tdns.toks.api.domain.study.controller;
 import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.*;
 import com.tdns.toks.api.domain.study.service.StudyApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
+import com.tdns.toks.core.domain.study.type.StudyUserStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -113,8 +114,10 @@ public class StudyController {
             @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
     public ResponseEntity<StudiesInfoResponse> getUserAllStudies(
+            @RequestParam(defaultValue = "ACTIVE") StudyUserStatus status
+
     ) {
-        var response = studyApiService.getAllStudies();
+        var response = studyApiService.getAllStudies(status);
         return ResponseDto.ok(response);
     }
 
@@ -130,8 +133,9 @@ public class StudyController {
             @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
     public ResponseEntity<StudiesInfoResponse> getUserInProgressStudies(
+            @RequestParam(defaultValue = "ACTIVE") StudyUserStatus status
     ) {
-        var response = studyApiService.getInProgressStudies();
+        var response = studyApiService.getInProgressStudies(status);
         return ResponseDto.ok(response);
     }
 
@@ -147,8 +151,9 @@ public class StudyController {
             @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
     public ResponseEntity<FinishedStudiesInfoResponse> getUserFinishedStudies(
+            @RequestParam(defaultValue = "ACTIVE") StudyUserStatus status
     ) {
-        var response = studyApiService.getFinishedStudies();
+        var response = studyApiService.getFinishedStudies(status);
         return ResponseDto.ok(response);
     }
 

--- a/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
@@ -1,35 +1,9 @@
 package com.tdns.toks.api.domain.study.controller;
 
-import java.util.List;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudiesInfoResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyApiResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyCreateRequest;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyDetailsResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyEntranceDetailsResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyFormResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.TagResponse;
 import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.*;
 import com.tdns.toks.api.domain.study.service.StudyApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
 import com.tdns.toks.core.domain.study.type.StudyStatus;
-
 import com.tdns.toks.core.domain.study.type.StudyUserStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,6 +14,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import java.util.List;
 
 // TODO : 해당 클래스에 있는 조회 로직에 대해 개선 작업이 필요함
 @Tag(name = "StudyController-V1", description = "STUDY API")
@@ -133,10 +116,10 @@ public class StudyController {
             @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
     public ResponseEntity<StudiesInfoResponse> getUserAllStudiesByStatus(
-            @RequestParam List<StudyStatus> statuses,
-            @RequestParam StudyUserStatus status
+            @RequestParam(defaultValue = "") List<StudyStatus> studyStatuses,
+            @RequestParam(defaultValue = "ACTIVE") StudyUserStatus joinStatus
     ) {
-        var response = studyApiService.getUserAllStudiesByStatus(statuses, status);
+        var response = studyApiService.getUserAllStudiesByStatus(studyStatuses, joinStatus);
         return ResponseDto.ok(response);
     }
 

--- a/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
@@ -1,32 +1,8 @@
 package com.tdns.toks.api.domain.study.controller;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
-
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.FinishedStudiesInfoResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudiesInfoResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyApiResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyCreateRequest;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyDetailsResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyEntranceDetailsResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyFormResponse;
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.TagResponse;
+import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.*;
 import com.tdns.toks.api.domain.study.service.StudyApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -36,6 +12,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 
 // TODO : 해당 클래스에 있는 조회 로직에 대해 개선 작업이 필요함
 @Tag(name = "StudyController-V1", description = "STUDY API")
@@ -220,5 +204,23 @@ public class StudyController {
     ) {
         var response = studyApiService.deleteAllByLeaderId(userId);
         return ResponseDto.ok(response);
+    }
+
+    @PostMapping("/{studyId}/leave")
+    @Operation(
+            method = "POST",
+            summary = "스터디 탈퇴"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "successful operation", content = @Content),
+            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
+            @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
+            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
+    public ResponseEntity<Void> leaveStudy(
+            @PathVariable("studyId") @Valid @Positive @NotNull(message = "스터디 id는 필수 항목 입니다.") Long studyId
+    ){
+        studyApiService.leaveStudy(studyId);
+        return ResponseDto.noContent();
     }
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
@@ -1,14 +1,5 @@
 package com.tdns.toks.api.domain.study.service;
 
-import static com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.tdns.toks.api.domain.study.event.publish.TagDictionaryEventPublish;
 import com.tdns.toks.api.domain.study.model.mapper.StudyApiMapper;
 import com.tdns.toks.core.common.exception.ApplicationErrorType;
@@ -22,15 +13,23 @@ import com.tdns.toks.core.domain.study.model.entity.Study;
 import com.tdns.toks.core.domain.study.model.entity.StudyUser;
 import com.tdns.toks.core.domain.study.service.StudyService;
 import com.tdns.toks.core.domain.study.service.StudyTagService;
+import com.tdns.toks.core.domain.study.service.StudyUserService;
 import com.tdns.toks.core.domain.study.type.StudyCapacity;
 import com.tdns.toks.core.domain.study.type.StudyStatus;
 import com.tdns.toks.core.domain.study.type.StudyUserStatus;
 import com.tdns.toks.core.domain.user.model.dto.UserDetailDTO;
 import com.tdns.toks.core.domain.user.model.dto.UserSimpleDTO;
 import com.tdns.toks.core.domain.user.service.UserService;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.*;
 
 // TODO : 단건 조회시, 한번에 쿼리가 조회되도록 구현
 // TODO : 개선 작업 필요 -> 스터디의 상태를 쿼리파람으로 받아서 하도록 구현해야 함.. 현재 로직은 잘못된 로직 (상태에 따라 API를 모두 만드는 건 바람직하지 않음)
@@ -45,6 +44,7 @@ public class StudyApiService {
     private final StudyTagService tagService;
     private final StudyApiMapper mapper;
     private final QuizService quizService;
+    private final StudyUserService studyUserService;
 
     public StudyApiResponse createStudy(StudyCreateRequest studyCreateRequest) {
         var userDTO = UserDetailDTO.get();
@@ -131,14 +131,14 @@ public class StudyApiService {
         }
     }
 
-    public StudiesInfoResponse getUserAllStudiesByStatus(List<StudyStatus> statuses, StudyUserStatus status) {
+    public StudiesInfoResponse getUserAllStudiesByStatus(List<StudyStatus> studyStatuses, StudyUserStatus joinedStatus) {
         var userId = UserDetailDTO.get().getId();
-        var userStudies = userService.getUserStudyIds(userId, status);
+        var userStudies = userService.getUserStudyIds(userId, joinedStatus);
         var usersStudyIds = userStudies.stream()
             .map(StudyUser::getStudyId)
             .collect(Collectors.toList());
 
-        var studies = studyService.findAllStudiesByStatus(usersStudyIds, statuses)
+        var studies = studyService.findAllStudiesByStatus(usersStudyIds, studyStatuses)
             .stream()
             .map(study -> getStudyInfo(study, userId))
             .collect(Collectors.toList());
@@ -196,5 +196,10 @@ public class StudyApiService {
 
     public Long deleteAllByLeaderId(Long leaderId) {
         return studyService.deleteAllByLeaderId(leaderId);
+    }
+
+    public void leaveStudy(Long studyId) {
+        var userId = UserDetailDTO.get().getId();
+        studyUserService.leaveStudy(studyId, userId);
     }
 }

--- a/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
@@ -138,9 +138,9 @@ public class StudyApiService {
         }
     }
 
-    public StudiesInfoResponse getAllStudies() {
+    public StudiesInfoResponse getAllStudies(StudyUserStatus status) {
         var userId = UserDetailDTO.get().getId();
-        var userStudies = userService.getUserStudyIds(userId);
+        var userStudies = userService.getUserStudyIds(userId, status);
         var usersStudyIds = userStudies.stream()
                 .map(StudyUser::getStudyId)
                 .collect(Collectors.toList());
@@ -153,9 +153,9 @@ public class StudyApiService {
         return new StudiesInfoResponse(studies);
     }
 
-    public StudiesInfoResponse getInProgressStudies() {
+    public StudiesInfoResponse getInProgressStudies(StudyUserStatus status) {
         var userId = UserDetailDTO.get().getId();
-        var studyUsers = userService.getUserStudyIds(userId);
+        var studyUsers = userService.getUserStudyIds(userId, status);
         var usersStudyIds = studyUsers.stream()
                 .map(StudyUser::getStudyId)
                 .collect(Collectors.toList());
@@ -217,9 +217,9 @@ public class StudyApiService {
         return StudyEntranceDetailsResponse.toResponse(study, tags);
     }
 
-    public FinishedStudiesInfoResponse getFinishedStudies() {
+    public FinishedStudiesInfoResponse getFinishedStudies(StudyUserStatus status) {
         var userId = UserDetailDTO.get().getId();
-        var userFinishedStudies = userService.getUserStudyIds(userId);
+        var userFinishedStudies = userService.getUserStudyIds(userId, status);
 
         var usersStudyIds = userFinishedStudies.stream()
                 .map(StudyUser::getStudyId)

--- a/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
@@ -14,6 +14,7 @@ import com.tdns.toks.core.domain.study.model.entity.Study;
 import com.tdns.toks.core.domain.study.model.entity.StudyUser;
 import com.tdns.toks.core.domain.study.service.StudyService;
 import com.tdns.toks.core.domain.study.service.StudyTagService;
+import com.tdns.toks.core.domain.study.service.StudyUserService;
 import com.tdns.toks.core.domain.study.type.StudyCapacity;
 import com.tdns.toks.core.domain.study.type.StudyStatus;
 import com.tdns.toks.core.domain.study.type.StudyUserStatus;
@@ -50,6 +51,7 @@ public class StudyApiService {
     private final StudyTagService tagService;
     private final StudyApiMapper mapper;
     private final QuizService quizService;
+    private final StudyUserService studyUserService;
 
     public StudyApiResponse createStudy(StudyCreateRequest studyCreateRequest) {
         var userDTO = UserDetailDTO.get();
@@ -236,5 +238,10 @@ public class StudyApiService {
 
     public Long deleteAllByLeaderId(Long leaderId) {
         return studyService.deleteAllByLeaderId(leaderId);
+    }
+
+    public void leaveStudy(Long studyId) {
+        var userId = UserDetailDTO.get().getId();
+        studyUserService.leaveStudy(studyId, userId);
     }
 }

--- a/core/src/main/java/com/tdns/toks/core/common/exception/ApplicationErrorType.java
+++ b/core/src/main/java/com/tdns/toks/core/common/exception/ApplicationErrorType.java
@@ -55,6 +55,7 @@ public enum ApplicationErrorType {
      * Study Error Type
      **/
     NOT_FOUND_STUDY(HttpStatus.NOT_FOUND, -30000, "스터디를 찾을 수 없습니다."),
+    NOT_JOINED_STUDY(HttpStatus.NOT_FOUND, -30001, "스터디에 참여하고있지 않습니다."),
 
     ;
 

--- a/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyUserRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyUserRepository.java
@@ -1,6 +1,7 @@
 package com.tdns.toks.core.domain.study.repository;
 
 import com.tdns.toks.core.domain.study.model.entity.StudyUser;
+import com.tdns.toks.core.domain.study.type.StudyUserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,8 +18,8 @@ public interface StudyUserRepository extends JpaRepository<StudyUser, Long>, Stu
 
     List<StudyUser> findAllByStudyId(long studyId);
 
-    @Query(value = "select su from StudyUser su where su.userId = :userId and su.status = 'ACTIVE'")
-    List<StudyUser> findAllJoinedStudyByUserId (@Param("userId") long userId);
+    @Query(value = "select su from StudyUser su where su.userId = :userId and su.status = :status")
+    List<StudyUser> findAllJoinedStudyByUserId (@Param("userId") long userId, @Param("status") StudyUserStatus status);
 
     Optional<StudyUser> findByStudyIdAndUserId(long studyId, long userId);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyUserRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyUserRepository.java
@@ -18,8 +18,8 @@ public interface StudyUserRepository extends JpaRepository<StudyUser, Long>, Stu
 
     List<StudyUser> findAllByStudyId(long studyId);
 
-    @Query(value = "select su from StudyUser su where su.userId = :userId and su.status = :status")
-    List<StudyUser> findAllJoinedStudyByUserId (@Param("userId") long userId, @Param("status") StudyUserStatus status);
+    @Query(value = "select su from StudyUser su where su.userId = :userId and su.status = :joinedStatus")
+    List<StudyUser> findAllJoinedStudyByUserId (@Param("userId") long userId, @Param("joinedStatus") StudyUserStatus joinedStatus);
 
     Optional<StudyUser> findByStudyIdAndUserId(long studyId, long userId);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyUserRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyUserRepository.java
@@ -2,9 +2,12 @@ package com.tdns.toks.core.domain.study.repository;
 
 import com.tdns.toks.core.domain.study.model.entity.StudyUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface StudyUserRepository extends JpaRepository<StudyUser, Long>, StudyUserCustomRepository {
@@ -13,4 +16,9 @@ public interface StudyUserRepository extends JpaRepository<StudyUser, Long>, Stu
     List<StudyUser> findAllByUserId(long userId);
 
     List<StudyUser> findAllByStudyId(long studyId);
+
+    @Query(value = "select su from StudyUser su where su.userId = :userId and su.status = 'ACTIVE'")
+    List<StudyUser> findAllJoinedStudyByUserId (@Param("userId") long userId);
+
+    Optional<StudyUser> findByStudyIdAndUserId(long studyId, long userId);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyService.java
@@ -1,12 +1,5 @@
 package com.tdns.toks.core.domain.study.service;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import com.tdns.toks.core.common.exception.ApplicationErrorException;
 import com.tdns.toks.core.common.exception.ApplicationErrorType;
 import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
@@ -21,8 +14,13 @@ import com.tdns.toks.core.domain.study.repository.TagRepository;
 import com.tdns.toks.core.domain.study.type.StudyStatus;
 import com.tdns.toks.core.domain.user.model.entity.User;
 import com.tdns.toks.core.domain.user.repository.UserRepository;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -117,8 +115,8 @@ public class StudyService {
                 .orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.NOT_FOUND_STUDY, "not found study " + studyId));
     }
 
-    public List<Study> findAllStudiesByStatus(List<Long> studyIds, List<StudyStatus> statuses) {
-        return studyRepository.retrieveByIdsAndStatuses(studyIds, statuses);
+    public List<Study> findAllStudiesByStatus(List<Long> studyIds, List<StudyStatus> studyStatuses) {
+        return studyRepository.retrieveByIdsAndStatuses(studyIds, studyStatuses);
     }
 
     public StudyUser saveStudyUser(StudyUser studyUser) {

--- a/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyUserService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyUserService.java
@@ -1,6 +1,10 @@
 package com.tdns.toks.core.domain.study.service;
 
+import com.tdns.toks.core.common.exception.ApplicationErrorType;
+import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
+import com.tdns.toks.core.domain.study.model.entity.StudyUser;
 import com.tdns.toks.core.domain.study.repository.StudyUserRepository;
+import com.tdns.toks.core.domain.study.type.StudyUserStatus;
 import com.tdns.toks.core.domain.user.model.dto.UserSimpleByQuizIdDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -34,5 +38,11 @@ public class StudyUserService {
 
                     return new UserSimpleByQuizIdDTO(participant.getQuizId(), unSubmitters);
                 }).collect(Collectors.toList());
+    }
+
+    public void leaveStudy(Long studyId, Long userId) {
+        StudyUser studyUser = studyUserRepository.findByStudyIdAndUserId(studyId, userId)
+                .orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.NOT_JOINED_STUDY));
+        studyUser.setStatus(StudyUserStatus.INACTIVE);
     }
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/user/service/UserService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/service/UserService.java
@@ -61,7 +61,7 @@ public class UserService {
     }
 
     public List<StudyUser> getUserStudyIds(Long userId) {
-        return studyUserRepository.findAllByUserId(userId);
+        return studyUserRepository.findAllJoinedStudyByUserId(userId);
     }
 
     private boolean isNicknameDuplicated(String nickname) {

--- a/core/src/main/java/com/tdns/toks/core/domain/user/service/UserService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
 import com.tdns.toks.core.common.security.JwtTokenProvider;
 import com.tdns.toks.core.domain.study.model.entity.StudyUser;
 import com.tdns.toks.core.domain.study.repository.StudyUserRepository;
+import com.tdns.toks.core.domain.study.type.StudyUserStatus;
 import com.tdns.toks.core.domain.user.model.entity.User;
 import com.tdns.toks.core.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -60,8 +61,8 @@ public class UserService {
         user.setRefreshToken("logout");
     }
 
-    public List<StudyUser> getUserStudyIds(Long userId) {
-        return studyUserRepository.findAllJoinedStudyByUserId(userId);
+    public List<StudyUser> getUserStudyIds(Long userId, StudyUserStatus status) {
+        return studyUserRepository.findAllJoinedStudyByUserId(userId, status);
     }
 
     private boolean isNicknameDuplicated(String nickname) {

--- a/core/src/main/java/com/tdns/toks/core/domain/user/service/UserService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/user/service/UserService.java
@@ -61,8 +61,8 @@ public class UserService {
         user.setRefreshToken("logout");
     }
 
-    public List<StudyUser> getUserStudyIds(Long userId, StudyUserStatus status) {
-        return studyUserRepository.findAllJoinedStudyByUserId(userId, status);
+    public List<StudyUser> getUserStudyIds(Long userId, StudyUserStatus joinedStatus) {
+        return studyUserRepository.findAllJoinedStudyByUserId(userId, joinedStatus);
     }
 
     private boolean isNicknameDuplicated(String nickname) {


### PR DESCRIPTION
## ✔️ PR 타입

- 기능 개선

## 📃 개요

- 사용자가 스터디를 탈퇴합니다.

## ✏️ 변경사항

- 사용자가 스터디를 탈퇴합니다.
   - 스터디 탈퇴 시 StudyUser의 Status를 INACTIVE로 변경합니다.

- 기존 스터디 조회 로직을 변경했습니다.
   - Query문에서 StudyUser의 Status = 'ACTIVE' 조건을 추가하였습니다.

## 🫥 TODO

- [ ] QueryDSL을 활용하여 조회 로직을 개선합니다. (3/12 까지)
