### PR TITLE
스터디 상태별 API 쿼리 스트링으로 변경

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/controller/StudyController.java
@@ -1,5 +1,7 @@
 package com.tdns.toks.api.domain.study.controller;
 
+import java.util.List;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
@@ -16,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.FinishedStudiesInfoResponse;
 import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudiesInfoResponse;
 import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyApiResponse;
 import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyCreateRequest;
@@ -26,6 +27,7 @@ import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.StudyFormResponse;
 import com.tdns.toks.api.domain.study.model.dto.StudyApiDTO.TagResponse;
 import com.tdns.toks.api.domain.study.service.StudyApiService;
 import com.tdns.toks.core.common.model.dto.ResponseDto;
+import com.tdns.toks.core.domain.study.type.StudyStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -120,7 +122,7 @@ public class StudyController {
     @GetMapping
     @Operation(
             method = "GET",
-            summary = "사용자 모든 스터디 목록 조회"
+            summary = "사용자 스터디 목록 조회"
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = StudiesInfoResponse.class))}),
@@ -128,43 +130,8 @@ public class StudyController {
             @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
             @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
             @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
-    public ResponseEntity<StudiesInfoResponse> getUserAllStudies(
-    ) {
-        var response = studyApiService.getAllStudies();
-        return ResponseDto.ok(response);
-    }
-
-    @GetMapping("/in-progress")
-    @Operation(
-            method = "GET",
-            summary = "진행중 사용자 스터디 목록 조회"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = StudiesInfoResponse.class))}),
-            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
-            @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
-            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
-    public ResponseEntity<StudiesInfoResponse> getUserInProgressStudies(
-    ) {
-        var response = studyApiService.getInProgressStudies();
-        return ResponseDto.ok(response);
-    }
-
-    @GetMapping("/finished")
-    @Operation(
-            method = "GET",
-            summary = "사용자 종료된 스터디 목록 조회"
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "successful operation", content = {@Content(mediaType = "application/json", schema = @Schema(implementation = FinishedStudiesInfoResponse.class))}),
-            @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content),
-            @ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content),
-            @ApiResponse(responseCode = "401", description = "Invalid Access Token", content = @Content),
-            @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content)})
-    public ResponseEntity<FinishedStudiesInfoResponse> getUserFinishedStudies(
-    ) {
-        var response = studyApiService.getFinishedStudies();
+    public ResponseEntity<StudiesInfoResponse> getUserAllStudiesByStatus(@RequestParam List<StudyStatus> statuses) {
+        var response = studyApiService.getUserAllStudiesByStatus(statuses);
         return ResponseDto.ok(response);
     }
 

--- a/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/study/service/StudyApiService.java
@@ -132,17 +132,13 @@ public class StudyApiService {
     }
 
     public StudiesInfoResponse getUserAllStudiesByStatus(List<StudyStatus> statuses) {
-        var userId = 5l;
+        var userId = UserDetailDTO.get().getId();
         var userStudies = userService.getUserStudyIds(userId);
         var usersStudyIds = userStudies.stream()
             .map(StudyUser::getStudyId)
             .collect(Collectors.toList());
 
-        if (statuses.isEmpty()) {
-            statuses = List.of(StudyStatus.values());
-        }
-
-        var studies = studyService.findStudyAllByStatus(usersStudyIds, statuses)
+        var studies = studyService.findAllStudiesByStatus(usersStudyIds, statuses)
             .stream()
             .map(study -> getStudyInfo(study, userId))
             .collect(Collectors.toList());

--- a/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyCustomRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyCustomRepository.java
@@ -1,0 +1,11 @@
+package com.tdns.toks.core.domain.study.repository;
+
+import java.util.List;
+
+import com.tdns.toks.core.domain.study.model.entity.Study;
+import com.tdns.toks.core.domain.study.type.StudyStatus;
+
+public interface StudyCustomRepository {
+
+	List<Study> retrieveByIdsAndStatuses(List<Long> ids, List<StudyStatus> statuses);
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyCustomRepositoryImpl.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyCustomRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.tdns.toks.core.domain.study.repository;
+
+import static com.tdns.toks.core.domain.study.model.entity.QStudy.*;
+
+import java.util.List;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tdns.toks.core.domain.study.model.entity.Study;
+import com.tdns.toks.core.domain.study.type.StudyStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class StudyCustomRepositoryImpl implements StudyCustomRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Study> retrieveByIdsAndStatuses(List<Long> ids, List<StudyStatus> statuses) {
+		return queryFactory
+			.selectFrom(study)
+			.where(study.id.in(ids).and(inStatus(statuses)))
+			.fetch();
+	}
+
+	private BooleanExpression inStatus(List<StudyStatus> statuses) {
+		if (statuses.isEmpty()) {
+			return null;
+		}
+		return study.status.in(statuses);
+	}
+}

--- a/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyRepository.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/repository/StudyRepository.java
@@ -1,14 +1,15 @@
 package com.tdns.toks.core.domain.study.repository;
 
-import com.tdns.toks.core.domain.study.model.entity.Study;
+import java.time.LocalDateTime;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
+import com.tdns.toks.core.domain.study.model.entity.Study;
 
 @Repository
-public interface StudyRepository extends JpaRepository<Study, Long> {
-    Long deleteAllByLeaderId(Long leaderId);
+public interface StudyRepository extends JpaRepository<Study, Long>, StudyCustomRepository {
+	Long deleteAllByLeaderId(Long leaderId);
 
-    Long countByCreatedAtBetween(LocalDateTime startAt, LocalDateTime endAt);
+	Long countByCreatedAtBetween(LocalDateTime startAt, LocalDateTime endAt);
 }

--- a/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyService.java
@@ -117,13 +117,8 @@ public class StudyService {
                 .orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.NOT_FOUND_STUDY, "not found study " + studyId));
     }
 
-    public List<Study> findStudyAllByStatus(List<Long> studyIds, List<StudyStatus> statuses) {
-        return studyRepository.findAllById(studyIds)
-            .stream()
-            .filter(study -> statuses
-                .stream()
-                .anyMatch(studyStatus -> study.getStatus().equals(studyStatus)))
-            .collect(Collectors.toList());
+    public List<Study> findAllStudiesByStatus(List<Long> studyIds, List<StudyStatus> statuses) {
+        return studyRepository.retrieveByIdsAndStatuses(studyIds, statuses);
     }
 
     public StudyUser saveStudyUser(StudyUser studyUser) {

--- a/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyService.java
+++ b/core/src/main/java/com/tdns/toks/core/domain/study/service/StudyService.java
@@ -1,5 +1,12 @@
 package com.tdns.toks.core.domain.study.service;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import com.tdns.toks.core.common.exception.ApplicationErrorException;
 import com.tdns.toks.core.common.exception.ApplicationErrorType;
 import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
@@ -14,13 +21,8 @@ import com.tdns.toks.core.domain.study.repository.TagRepository;
 import com.tdns.toks.core.domain.study.type.StudyStatus;
 import com.tdns.toks.core.domain.user.model.entity.User;
 import com.tdns.toks.core.domain.user.repository.UserRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional
@@ -115,8 +117,13 @@ public class StudyService {
                 .orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.NOT_FOUND_STUDY, "not found study " + studyId));
     }
 
-    public List<Study> findStudyAll(List<Long> studyIds) {
-        return studyRepository.findAllById(studyIds);
+    public List<Study> findStudyAllByStatus(List<Long> studyIds, List<StudyStatus> statuses) {
+        return studyRepository.findAllById(studyIds)
+            .stream()
+            .filter(study -> statuses
+                .stream()
+                .anyMatch(studyStatus -> study.getStatus().equals(studyStatus)))
+            .collect(Collectors.toList());
     }
 
     public StudyUser saveStudyUser(StudyUser studyUser) {
@@ -126,11 +133,6 @@ public class StudyService {
     @Transactional(readOnly = true)
     public boolean existStudyUser(long userId, long studyId) {
         return studyUserRepository.existsByUserIdAndStudyId(userId, studyId);
-    }
-
-    public boolean isFinishedStudy(Long studyId) {
-        Study study = getStudy(studyId);
-        return study.getStatus() == StudyStatus.FINISH;
     }
 
     public List<User> getUsersInStudy(Long studyId) {


### PR DESCRIPTION
## ✔️ PR 타입
- 수정

## 📃 개요
- 스터디 상태별 API 가 나누어져 있어서, 쿼리 스트링으로 조회할 수 있게 변경하였는데, 이 방식은 어떨까요?!
```
GET /api/v1/studies?statuses=IN_PROGRESS,READY
```
- 괜찮으시면 status 가 empty 인경우, 하드 코딩 되어있는 부분을 리팩토링 진행 예정입니다.

## ✏️ 변경사항

## 🫥 TODO
