### PR TITLE
Feature/157

### DIFF
--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizCommentController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizCommentController.java
@@ -1,6 +1,7 @@
 package com.tdns.toks.api.domain.quiz.controller;
 
 import com.tdns.toks.api.domain.quiz.service.QuizCommentService;
+import com.tdns.toks.core.common.annotation.UserDto;
 import com.tdns.toks.core.common.model.dto.PageableResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,6 +25,12 @@ public class QuizCommentController {
     @GetMapping("/quiz/test")
     public ResponseEntity<String> test() {
         return ResponseEntity.ok("testHere");
+    }
+
+    @Operation(summary = "api v2 토큰 테스트", description = "토큰 리졸버 확인용")
+    @GetMapping("/quiz/token")
+    public ResponseEntity<String> test(@UserDto String email) {
+        return ResponseEntity.ok(email);
     }
 
     @Operation(summary = "댓글 다건 조회", description = "내림차순으로 제공")

--- a/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizCommentController.java
+++ b/api/src/main/java/com/tdns/toks/api/domain/quiz/controller/QuizCommentController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,10 +15,16 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "퀴즈 댓글 관리", description = "QUIZ Comment API")
 @RestController
-@RequestMapping(path = "/api/v1", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(path = "/api/v2", produces = MediaType.APPLICATION_JSON_VALUE)
 @RequiredArgsConstructor
 public class QuizCommentController {
     private final QuizCommentService quizCommentService;
+
+    @Operation(summary = "api v2 테스트", description = "permit all 확인용")
+    @GetMapping("/quiz/test")
+    public ResponseEntity<String> test() {
+        return ResponseEntity.ok("testHere");
+    }
 
     @Operation(summary = "댓글 다건 조회", description = "내림차순으로 제공")
     @GetMapping("/quizzes/{quizId}/comments")

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -36,7 +36,9 @@ spring:
     pathmatch:
       matching-strategy: ant_path_matcher
   jwt:
-    secret: ENC(BF9EmOQPpQJ8n8uZwUgw37wHFDBQg9wCNHiZUcDnNTbQbHwUd//RIfjiCO38GavO7PIuCKm11FFVhKG1HofyiljZBCCD83eOzw9lWZi6VXE=)
+#    이전 시크릿 값 (향후 기간 동안 문제 없으면 추후 삭제하겠습니다)
+#    secret: ENC(BF9EmOQPpQJ8n8uZwUgw37wHFDBQg9wCNHiZUcDnNTbQbHwUd//RIfjiCO38GavO7PIuCKm11FFVhKG1HofyiljZBCCD83eOzw9lWZi6VXE=)
+    secret: ENC(ofbBXNe4Vl4UfHa8Kwsth0QTGo5Y4xn0dzs5AbdiedG32jSZCHyOzdFXqVhh2KAXzNuNT9F4ni2I6JEZ4Tsah4Js1u8HhZnrMkFtpq1rUJM=)
 
 server:
   port: 8080

--- a/core/src/main/java/com/tdns/toks/core/common/annotation/UserDto.java
+++ b/core/src/main/java/com/tdns/toks/core/common/annotation/UserDto.java
@@ -1,0 +1,11 @@
+package com.tdns.toks.core.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserDto {
+}

--- a/core/src/main/java/com/tdns/toks/core/common/exception/ApplicationErrorType.java
+++ b/core/src/main/java/com/tdns/toks/core/common/exception/ApplicationErrorType.java
@@ -21,7 +21,6 @@ public enum ApplicationErrorType {
     COULDNT_FIND_ANY_DATA(HttpStatus.BAD_REQUEST, "try.again"),
     CLIENT_ABORT(HttpStatus.BAD_REQUEST, "try.again"),
     FROM_JSON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "try.again"),
-    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "error.invalid.access.token"),
     INVALID_LOGIN_INFO(HttpStatus.BAD_REQUEST, "try.again"/*Invalid Login Info*/),
     TO_JSON_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "try.again"),
 
@@ -35,6 +34,9 @@ public enum ApplicationErrorType {
     AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "authentication failed"),
     EMPTY_TOKEN(HttpStatus.BAD_REQUEST, "no token"),
     NO_AUTHORIZATION(HttpStatus.UNAUTHORIZED, "error.no.authorization"),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "error.invalid.access.token"),
+    TOKEN_INTERNAL_ERROR(HttpStatus.UNAUTHORIZED, "토큰 verify 실패 (토큰 내부 값 오류)"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰"),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "error.invalid.refresh.token"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자 정보를 찾을 수 없습니다."),
 

--- a/core/src/main/java/com/tdns/toks/core/common/filter/JwtAuthenticationFilter.java
+++ b/core/src/main/java/com/tdns/toks/core/common/filter/JwtAuthenticationFilter.java
@@ -1,67 +1,68 @@
-package com.tdns.toks.core.common.filter;
-
-import com.tdns.toks.core.common.exception.ApplicationErrorType;
-import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
-import com.tdns.toks.core.common.security.JwtTokenProvider;
-import com.tdns.toks.core.domain.user.model.dto.UserDTO;
-import com.tdns.toks.core.domain.user.model.entity.User;
-import com.tdns.toks.core.domain.user.service.UserService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.List;
-
-@RequiredArgsConstructor
-@Component
-public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    @Value("#{'${security.filter-skip}' .split(',')}")
-    private final List<String> filterSkipUrl;
-
-    @Value("${security.permit-url}")
-    private final String[] permitUrl;
-
-    private final JwtTokenProvider jwtTokenProvider; // JWT 토큰을 생성 및 검증 모듈 클래스
-    private final UserService userService;
-
-    // Jwt Provider 주입
-
-    // Request로 들어오는 Jwt Token의 유효성을 검증 (jwtTokenProvider.validateToken)하는
-    // filter를 filterChain에 등록한다.
-
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = jwtTokenProvider.getAuthToken(request);
-
-        if (token != null) {
-            if (jwtTokenProvider.verifyToken(token)) {
-                String email = jwtTokenProvider.getUid(token);
-                User user = userService.getUserByStatus(email).orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.UNAUTHORIZED_USER));
-                Authentication auth = getAuthentication(UserDTO.convertEntityToDTO(user));
-                SecurityContextHolder.getContext().setAuthentication(auth);
-            } else {
-                throw new SilentApplicationErrorException(ApplicationErrorType.INVALID_ACCESS_TOKEN);
-            }
-        }
-        filterChain.doFilter(request, response);
-    }
-
-    // ????
-    public Authentication getAuthentication(UserDTO user) {
-        return new UsernamePasswordAuthenticationToken(
-                user,
-                "",
-                List.of(new SimpleGrantedAuthority(user.getUserRole().getAuthority()))
-        );
-    }
-}
+//package com.tdns.toks.core.common.filter;
+//
+//import com.tdns.toks.core.common.exception.ApplicationErrorType;
+//import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
+//import com.tdns.toks.core.common.security.JwtTokenProvider;
+//import com.tdns.toks.core.domain.user.model.dto.UserDTO;
+//import com.tdns.toks.core.domain.user.model.entity.User;
+//import com.tdns.toks.core.domain.user.service.UserService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.authority.SimpleGrantedAuthority;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//import org.springframework.stereotype.Component;
+//import org.springframework.web.filter.OncePerRequestFilter;
+//
+//import javax.servlet.FilterChain;
+//import javax.servlet.ServletException;
+//import javax.servlet.http.HttpServletRequest;
+//import javax.servlet.http.HttpServletResponse;
+//import java.io.IOException;
+//import java.util.List;
+//
+//@RequiredArgsConstructor
+//@Deprecated
+//@Component
+//public class JwtAuthenticationFilter extends OncePerRequestFilter {
+//    @Value("#{'${security.filter-skip}' .split(',')}")
+//    private final List<String> filterSkipUrl;
+//
+//    @Value("${security.permit-url}")
+//    private final String[] permitUrl;
+//
+//    private final JwtTokenProvider jwtTokenProvider; // JWT 토큰을 생성 및 검증 모듈 클래스
+//    private final UserService userService;
+//
+//    // Jwt Provider 주입
+//
+//    // Request로 들어오는 Jwt Token의 유효성을 검증 (jwtTokenProvider.validateToken)하는
+//    // filter를 filterChain에 등록한다.
+//
+//    @Override
+//    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+//        String token = jwtTokenProvider.getAuthToken(request);
+//
+//        if (token != null) {
+//            if (jwtTokenProvider.verifyToken(token)) {
+//                String email = jwtTokenProvider.getUid(token);
+//                User user = userService.getUserByStatus(email).orElseThrow(() -> new SilentApplicationErrorException(ApplicationErrorType.UNAUTHORIZED_USER));
+//                Authentication auth = getAuthentication(UserDTO.convertEntityToDTO(user));
+//                SecurityContextHolder.getContext().setAuthentication(auth);
+//            } else {
+//                throw new SilentApplicationErrorException(ApplicationErrorType.INVALID_ACCESS_TOKEN);
+//            }
+//        }
+//        filterChain.doFilter(request, response);
+//    }
+//
+//    // ????
+//    public Authentication getAuthentication(UserDTO user) {
+//        return new UsernamePasswordAuthenticationToken(
+//                user,
+//                "",
+//                List.of(new SimpleGrantedAuthority(user.getUserRole().getAuthority()))
+//        );
+//    }
+//}

--- a/core/src/main/java/com/tdns/toks/core/common/resolver/UserArgumentResolver.java
+++ b/core/src/main/java/com/tdns/toks/core/common/resolver/UserArgumentResolver.java
@@ -1,0 +1,25 @@
+package com.tdns.toks.core.common.resolver;
+
+import com.tdns.toks.core.common.annotation.UserDto;
+import com.tdns.toks.core.common.utils.TokenUtil;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import javax.servlet.http.HttpServletRequest;
+
+public class UserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(String.class)&&
+                parameter.hasParameterAnnotation(UserDto.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
+        return TokenUtil.getUserEmail(httpServletRequest);
+    }
+}

--- a/core/src/main/java/com/tdns/toks/core/common/security/JwtTokenProvider.java
+++ b/core/src/main/java/com/tdns/toks/core/common/security/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package com.tdns.toks.core.common.security;
 
-import com.google.common.net.HttpHeaders;
 import com.tdns.toks.core.common.type.AuthTokenType;
 import com.tdns.toks.core.common.type.JwtToken;
 import io.jsonwebtoken.Claims;

--- a/core/src/main/java/com/tdns/toks/core/common/utils/TokenUtil.java
+++ b/core/src/main/java/com/tdns/toks/core/common/utils/TokenUtil.java
@@ -1,0 +1,56 @@
+package com.tdns.toks.core.common.utils;
+
+import com.tdns.toks.core.common.exception.ApplicationErrorType;
+import com.tdns.toks.core.common.exception.SilentApplicationErrorException;
+import com.tdns.toks.core.common.type.AuthTokenType;
+import io.jsonwebtoken.*;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
+
+import static com.tdns.toks.core.common.security.Constants.TOKS_AUTH_HEADER_KEY;
+
+@Component
+public class TokenUtil {
+
+    private static String key;
+
+    @Value("${spring.jwt.secret}")
+    public void getSecretKey(String SECRET_KEY) {
+        key = SECRET_KEY;
+    }
+
+    public static String getAuthToken(HttpServletRequest request) {
+        String accessToken = request.getHeader(TOKS_AUTH_HEADER_KEY); //인증토큰 값 가져오기
+
+        if (StringUtils.startsWithIgnoreCase(accessToken, AuthTokenType.BEARER_TYPE.getTokenType())) {
+            return StringUtils.replaceIgnoreCase(accessToken, AuthTokenType.BEARER_TYPE.getTokenType(), "");
+        }
+
+        if (StringUtils.isNotEmpty(accessToken)) {
+            return accessToken;
+        }
+        return null;
+    }
+
+    public static void verifyToken(String token) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(key.getBytes()).parseClaimsJws(token);
+//            Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJwt(token).getBody();
+            if (!claims.getBody().getExpiration().after(new Date())) { // 토큰 만료 시
+                throw new SilentApplicationErrorException(ApplicationErrorType.EXPIRED_TOKEN);
+            }
+        } catch (Exception e) {
+            throw new SilentApplicationErrorException(ApplicationErrorType.TOKEN_INTERNAL_ERROR);
+        }
+    }
+
+    public static String getUserEmail(HttpServletRequest request) {
+        String token = getAuthToken(request);
+        verifyToken(token);
+        return Jwts.parser().setSigningKey(key.getBytes()).parseClaimsJws(token).getBody().getSubject();
+    }
+}

--- a/core/src/main/java/com/tdns/toks/core/config/security/AuthSecurityConfig.java
+++ b/core/src/main/java/com/tdns/toks/core/config/security/AuthSecurityConfig.java
@@ -92,7 +92,10 @@ public class AuthSecurityConfig extends WebSecurityConfigurerAdapter {
                 "/swagger-ui.html", "/webjars/**", "/swagger/**", "/swagger-ui/index.html",
 
                 // 임시로 추가, 인증인가 모듈에 대한 개선 필요..
-                "/api/v1/categories"
+                "/api/v1/categories",
+
+                // v2 API 시큐리티 적용 제외
+                "/api/v2/**"
         );
     }
 

--- a/core/src/main/java/com/tdns/toks/core/config/security/AuthSecurityConfig.java
+++ b/core/src/main/java/com/tdns/toks/core/config/security/AuthSecurityConfig.java
@@ -2,7 +2,6 @@ package com.tdns.toks.core.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tdns.toks.core.common.filter.ExceptionHandlerFilter;
-import com.tdns.toks.core.common.filter.JwtAuthenticationFilter;
 import com.tdns.toks.core.common.security.oauth.CustomOAuth2UserService;
 import com.tdns.toks.core.common.security.oauth.OAuth2FailureHandler;
 import com.tdns.toks.core.common.security.oauth.OAuth2SuccessHandler;
@@ -40,7 +39,7 @@ public class AuthSecurityConfig extends WebSecurityConfigurerAdapter {
     private final UserDetailService customUserDetailService;
     private final ExceptionHandlerFilter exceptionHandlerFilter;
 
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+//    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
@@ -80,8 +79,9 @@ public class AuthSecurityConfig extends WebSecurityConfigurerAdapter {
                 .successHandler(oAuth2SuccessHandler)
                 .failureHandler(oAuth2FailureHandler);
 
-        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-        http.addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
+        http.addFilterBefore(exceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class);
+//        http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+//        http.addFilterBefore(exceptionHandlerFilter, JwtAuthenticationFilter.class);
     }
 
     @Override

--- a/core/src/main/java/com/tdns/toks/core/config/web/WebConfig.java
+++ b/core/src/main/java/com/tdns/toks/core/config/web/WebConfig.java
@@ -1,0 +1,16 @@
+package com.tdns.toks.core.config.web;
+
+import com.tdns.toks.core.common.resolver.UserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new UserArgumentResolver());
+    }
+}


### PR DESCRIPTION
## ✔️ PR 타입
기능 개선

## 📃 개요

리졸버를 통한 토큰 검증
검증 후 사용자 이메일 추출

컨트롤러에서 `@UserDto String email` 을 통해 헤더의 토큰에서 사용자 email 추출.

## ✏️ 변경사항

SECERT_KEY 값 변경. 시크릿 키 값 내부 '_' 때문에 인코딩 및 디코딩 시 오류 지속 발생.
변경 내용 : 키값 변경 후 jasypt로 암호화 완료.

리졸버에 사용할 토큰 기능을 Util로 분리 (static class)

해당 작업 중, 키 변환 과정에서 문제 지속 발생 -> .getBytes() 추가하여 해결

## 🫥 TODO
